### PR TITLE
Simplify CMakeLists files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,255 @@
+
+# Created by https://www.gitignore.io/api/git,linux,macos,python,windows,pycharm,jupyternotebook
+
+### Git ###
+*.orig
+
+### JupyterNotebook ###
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+#
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VScode ###
+.vscode/*
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+.idea/*
+
+# User-specific stuff:
+.idea/**/*.iml
+.idea/**/workspace.xml
+.idea/**/vcs.xml
+.idea/**/tasks.xml
+.idea/**/misc.xml
+.idea/**/modules.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/*
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+build-conda/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# CAD formats
+*.igs
+
+# End of https://www.gitignore.io/api/git,linux,macos,python,windows,pycharm,jupyternotebook

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,77 +4,26 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 project(gbs LANGUAGES CXX)
 
-#
 # c++ conf
-#
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-#
-# set output dirs (vs is a pain)
-#
-function(SET_OUT_DIR REQUIRED_ARG)
-    list(GET ARGV 0 TARGET_NAME)
-    list(GET ARGV 1 OUT_DIR)
-    message(${TARGET_NAME})
-    message(${OUT_DIR})
-    foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
-        string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
-        set_property(TARGET ${TARGET_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${OUT_DIR} )
-        set_property(TARGET ${TARGET_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${OUT_DIR} )
-        set_property(TARGET ${TARGET_NAME} PROPERTY ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${OUT_DIR} )
-    endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
-endfunction()
-#
-# CODAN ENV
-#
-if(EXISTS $ENV{LIBRARY_PREFIX})
-    file(TO_CMAKE_PATH $ENV{LIBRARY_BIN} LIBRARY_BIN)
-    file(TO_CMAKE_PATH $ENV{LIBRARY_INC} LIBRARY_INC)
-    file(TO_CMAKE_PATH $ENV{LIBRARY_LIB} LIBRARY_LIB)
-elseif(EXISTS $ENV{CONDA_PREFIX})
-    file(TO_CMAKE_PATH $ENV{CONDA_PREFIX} CONDA_PREFIX)
-    file(TO_CMAKE_PATH ${CONDA_PREFIX}/Library/bin LIBRARY_BIN)
-    file(TO_CMAKE_PATH ${CONDA_PREFIX}/Library/include LIBRARY_INC)
-    file(TO_CMAKE_PATH ${CONDA_PREFIX}/Library/lib LIBRARY_LIB)
-else()
-    message(FATAL_ERROR "A conda environement is required")
-endif()
 
-message(${LIBRARY_LIB} ${LIBRARY_BIN} ${LIBRARY_INC})
-#
-# set install dir
-#
-function(SET_INSTALL_DIR REQUIRED_ARG)
-    list(GET ARGV 0 TARGET_NAME)
-    if(WIN32)
-        if(TARGET ${TARGET_NAME} )
-            install(TARGETS ${TARGET_NAME}
-                EXPORT  ${TARGET_NAME}Targets
-                COMPONENT python
-                LIBRARY  DESTINATION ${LIBRARY_LIB}
-                RUNTIME  DESTINATION ${LIBRARY_BIN}
-                INCLUDES DESTINATION ${LIBRARY_INC}
-                ARCHIVE  DESTINATION ${LIBRARY_LIB}
-            )
-            install(
-                EXPORT  ${TARGET_NAME}Targets
-                FILE ${TARGET_NAME}.cmake
-                NAMESPACE GBS::
-                DESTINATION ${LIBRARY_LIB}/cmake/${TARGET_NAME}
-            )
-        endif(TARGET ${TARGET_NAME} )
-    else() # TODO find export dir for linux
-            install(TARGETS ${TARGET_NAME}  
-            LIBRARY DESTINATION $ENV{LD_RUN_PATH}
-            )
-    endif()
+# Set installation directories (CMAKE_INSTALL_INCLUDEDIR, CMAKE_INSTALL_BINDIR, CMAKE_INSTALL_LIBDIR)
+include(GNUInstallDirs)
+
+message("-- CMake install prefix: " ${CMAKE_INSTALL_PREFIX})
+message("  -> binaries: " ${CMAKE_INSTALL_BINDIR})
+message("  -> libs: " ${CMAKE_INSTALL_LIBDIR})
+message("  -> includes: " ${CMAKE_INSTALL_INCLUDEDIR})
+
+function(INSTALL_HEADERS REQUIRED_ARG)
     # copy headers keeping file structure
     string(TOLOWER ${PROJECT_NAME} inc_sub_dir)
     install(
             DIRECTORY "${CMAKE_SOURCE_DIR}/${inc_sub_dir}"
-            DESTINATION "${LIBRARY_INC}"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
             FILES_MATCHING PATTERN "*.h"
             PATTERN "cmake" EXCLUDE
             PATTERN "tests" EXCLUDE
@@ -87,62 +36,59 @@ function(SET_INSTALL_DIR REQUIRED_ARG)
     )
 endfunction()
 
-include_directories(${LIBRARY_INC})
-link_directories(${LIBRARY_BIN})
-link_directories(${LIBRARY_LIB})
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-#
+
 # Boost
-# 
-# set(BOOST_DIR ${LIBRARY_LIB}/cmake/Boost-1.74.0)
-# set(Boost_INCLUDE_DIR ${LIBRARY_INC})
 find_package(Boost REQUIRED)
-#
-# eigen
-#
-include_directories(${LIBRARY_INC}/eigen3)
-# 
+
+# Eigen
+find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+include_directories(${EIGEN3_INCLUDE_DIR})
+
 # VTK
-# 
-set(VTK_DIR  ${LIBRARY_LIB}/cmake/vtk-9.0)
-include_directories(${LIBRARY_INC}/vtk-9.0)
 find_package(VTK COMPONENTS
             CommonCore
             CommonColor
             CommonDataModel
             FiltersSources
+            FiltersGeneral
             InteractionStyle
             RenderingCore
             RenderingFreeType
             RenderingOpenGL2)
-#
+
 # occt
-# 
-set(OpenCASCADE_DIR ${CONDA_PREFIX}/Library/lib/cmake/opencascade)
-find_package(OpenCASCADE )
+find_package(OpenCASCADE REQUIRED)
 link_directories(${OpenCASCADE_LIBRARY_DIR})
 include_directories(${OpenCASCADE_INCLUDE_DIR})
 add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING) # occt interators seems to be old
-#
-# current tested lib
-# 
-link_directories(${CMAKE_BINARY_DIR})
-############
 
-SET_INSTALL_DIR(${PROJECT_NAME})
+INSTALL_HEADERS(${PROJECT_NAME})
 
+# Tests
+if(${GBS_BUILD_TESTS})
+    # Google Tests #
+    find_package(GTest REQUIRED)
+    include_directories(${GTEST_INCLUDE_DIRS})
+    link_directories(${GTEST_LIBRARIES})
+
+    message(STATUS "gtest include dirs: " ${GTEST_INCLUDE_DIRS})
+    message(STATUS "gtest lib dirs: " ${GTEST_LIBRARIES})
+    
+    add_subdirectory(tests)
+endif(${GBS_BUILD_TESTS})
+
+# OCCT utils
 if(${GBS_BUILD_TESTS} OR ${USE_OCCT_UTILS})
     add_subdirectory(gbs-occt)
 endif(${GBS_BUILD_TESTS} OR ${USE_OCCT_UTILS})
 
-if(${USE_RENDER})
+# Rendering module
+if(${USE_RENDER} OR ${GBS_BUILD_TESTS})
     add_subdirectory(gbs-render)
 endif(${USE_RENDER})
 
-if(${GBS_BUILD_TESTS})
-    add_subdirectory(tests)
-endif(${GBS_BUILD_TESTS})
-if(${USE_PYTHON_BIDING})
+# Python bindings
+if(${USE_PYTHON_BINDINGS})
     add_subdirectory(python)
-endif(${USE_PYTHON_BIDING})
+endif(${USE_PYTHON_BINDINGS})

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,7 +45,7 @@ The optional module gbs-occt requires the additional package:
 The optional module render requires the additional package:
 * vtk >=9.0
 
-The python biding requires the additional package:
+The python bindings requires the additional package:
 * pybind11
 
 The test library needs:
@@ -59,6 +59,6 @@ As GBS base is a header library it doesn’t need compilation.
 
 If one needs to compile the optional module gbs-occt, -DUSE_OCCT_UTILS:BOOL=TRUE shall be added to cmake command.
 If one needs to compile the optional module render, -DUSE_RENDER:BOOL=TRUE shall be added to cmake command.
-If one needs to compile the optional module python-binding, -DUSE_PYTHON_BIDING=TRUE shall be added to cmake command.
+If one needs to compile the optional module python-bindings, -DUSE_PYTHON_BINDINGS=TRUE shall be added to cmake command.
 
 The full test suite, which require the optional module gbs-occt, please add -DGBS_BUILD_TESTS:BOOL=TRUE to the cmake command.

--- a/gbs-occt/CMakeLists.txt
+++ b/gbs-occt/CMakeLists.txt
@@ -1,27 +1,21 @@
 cmake_minimum_required(VERSION 3.17.0)
 
-project(occt LANGUAGES CXX)
-# 
-# gbslib
-#
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-# 
-# set files fo lib
-# 
-file(GLOB OCCT_UTILS_SRC_LIST "*.cpp")
-add_library(gbs-${PROJECT_NAME} SHARED ${OCCT_UTILS_SRC_LIST})
-target_link_libraries(gbs-${PROJECT_NAME} ${OpenCASCADE_LIBRARIES})
+project(gbs-occt LANGUAGES CXX)
 
-if ( MSVC )
-    SET_OUT_DIR(gbs-${PROJECT_NAME} ${CMAKE_BINARY_DIR})
-endif ( MSVC )
-#
+# gbslib
+include_directories(${CMAKE_SOURCE_DIR})
+
+file(GLOB OCCT_UTILS_SRC_LIST "*.cpp")
+add_library(${PROJECT_NAME} SHARED ${OCCT_UTILS_SRC_LIST})
+target_link_libraries(${PROJECT_NAME} ${OpenCASCADE_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME})
+INSTALL_HEADERS(${PROJECT_NAME})
+
 # tests
-#
 # add current dir for include in tests
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 if(${GBS_BUILD_TESTS})
     add_subdirectory(tests)
 endif(${GBS_BUILD_TESTS})
 
-SET_INSTALL_DIR(gbs-${PROJECT_NAME})

--- a/gbs-occt/tests/CMakeLists.txt
+++ b/gbs-occt/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(gbs-occt_tests LANGUAGES CXX)
-#
-# add sources to test exe
-# 
+
 file(GLOB SRC_LIST "tests_*")
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 target_link_libraries(${PROJECT_NAME} 
@@ -10,6 +8,4 @@ target_link_libraries(${PROJECT_NAME}
                             ${OpenCASCADE_LIBRARIES} 
                             gbs-occt 
                     )
-if ( MSVC )
-    SET_OUT_DIR(${PROJECT_NAME} ${CMAKE_BINARY_DIR})
-endif ( MSVC )
+install(TARGETS ${PROJECT_NAME})

--- a/gbs-render/CMakeLists.txt
+++ b/gbs-render/CMakeLists.txt
@@ -1,35 +1,26 @@
 cmake_minimum_required(VERSION 3.17.0)
 
-project(render LANGUAGES CXX)
-# 
+project(gbs-render LANGUAGES CXX)
+
 # gbslib
-#
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-# 
-# set files fo lib
-# 
+include_directories(${CMAKE_SOURCE_DIR})
+
 file(GLOB GBS_RENDER_SRC_LIST "*.cpp")
-message( ${GBS_RENDER_SRC_LIST})
-add_library(gbs-${PROJECT_NAME} SHARED ${GBS_RENDER_SRC_LIST})
-target_link_libraries(gbs-${PROJECT_NAME} 
+add_library(${PROJECT_NAME} SHARED ${GBS_RENDER_SRC_LIST})
+target_link_libraries(${PROJECT_NAME} 
     ${VTK_LIBRARIES}
 )
-if ( MSVC )
-    SET_OUT_DIR(gbs-${PROJECT_NAME} ${CMAKE_BINARY_DIR})
-endif ( MSVC )
-#
-# tests
-#
-# add current dir for include in tests
 
+# tests
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 if(${GBS_BUILD_TESTS})
     add_subdirectory(tests)
 endif(${GBS_BUILD_TESTS})
 
 vtk_module_autoinit(
-        TARGETS gbs-${PROJECT_NAME}
+        TARGETS ${PROJECT_NAME}
         MODULES ${VTK_LIBRARIES}
 )
 
-SET_INSTALL_DIR(gbs-${PROJECT_NAME})
+install(TARGETS ${PROJECT_NAME})
+INSTALL_HEADERS(${PROJECT_NAME})

--- a/gbs-render/tests/CMakeLists.txt
+++ b/gbs-render/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(gbs-render_tests LANGUAGES CXX)
-#
-# add sources to test exe
-# 
+
 file(GLOB SRC_LIST "tests_*")
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 target_link_libraries(${PROJECT_NAME} 
@@ -16,17 +14,7 @@ target_link_libraries(${PROJECT_NAME}
                             nlopt
                             ${VTK_LIBRARIES}
                     )
-#
-# set output dirs (vs is a pain)
-#
-if ( MSVC )
-    foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
-        string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
-        set_property(TARGET ${PROJECT_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR} )
-        set_property(TARGET ${PROJECT_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR} )
-        set_property(TARGET ${PROJECT_NAME} PROPERTY ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR} )
-    endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
-endif ( MSVC )
+install(TARGETS ${PROJECT_NAME})
 
 vtk_module_autoinit(
         TARGETS ${PROJECT_NAME}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,32 +1,21 @@
 cmake_minimum_required(VERSION 3.17.0)
 
 project(pygbs LANGUAGES CXX)
-#
+
 # gslib
-#
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-# site-package dir
-if(EXISTS $ENV{SP_DIR})
-    file(TO_CMAKE_PATH $ENV{SP_DIR} SP_DIR)
-    set(${PROJECT_NAME}_INSTALL_DIRECTORY ${SP_DIR}/${PROJECT_NAME})
-else()
-    if(UNIX)
-        set(${PROJECT_NAME}_INSTALL_DIRECTORY ${CONDA_PREFIX}/lib/python${python_version_major}.${python_version_minor}/site-packages/${PROJECT_NAME})
-    else()
-        set(${PROJECT_NAME}_INSTALL_DIRECTORY ${CONDA_PREFIX}/Lib/site-packages/${PROJECT_NAME})
-    endif()
-endif()
+include_directories(${CMAKE_SOURCE_DIR})
+
+# Set installation directories
+find_package(PythonInterp)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; import os;print(get_python_lib())"
+                OUTPUT_VARIABLE PY_SP_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(SP_DIR "${PY_SP_DIR}" CACHE PATH "Site-package directory")
+message("  -> site-packages: " ${SP_DIR})
+
 find_package(pybind11 REQUIRED)
 pybind11_add_module(${PROJECT_NAME} gbsbind.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE nlopt)
 
-if ( MSVC )
-    SET_OUT_DIR(${PROJECT_NAME} ${CMAKE_BINARY_DIR})
-endif ( MSVC )
 install(TARGETS ${PROJECT_NAME} 
-    COMPONENT python
-    LIBRARY  DESTINATION ${LIBRARY_LIB}
-    RUNTIME  DESTINATION ${LIBRARY_BIN}
-    INCLUDES DESTINATION ${LIBRARY_INC}
-    ARCHIVE  DESTINATION ${LIBRARY_LIB}
-)
+        DESTINATION ${SP_DIR})

--- a/recipe/bld-dev.bat
+++ b/recipe/bld-dev.bat
@@ -1,0 +1,5 @@
+set LIBRARY_PREFIX=%CONDA_PREFIX%/Library
+
+CALL "recipe/bld.bat"
+
+set LIBRARY_PREFIX=

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,16 @@
-mkdir build-conda
-cd build-conda
+mkdir build
+cd build
+
 cmake .. ^
--DCMAKE_BUILD_TYPE:STRING="Release" ^
--DUSE_OCCT_UTILS:BOOL=TRUE ^
--DGBS_BUILD_TESTS:BOOL=TRUE ^
--DUSE_RENDER:BOOL=TRUE ^
--DUSE_PYTHON_BIDING=TRUE ^
--G"Ninja" ^
+-D CMAKE_BUILD_TYPE:STRING="Release" ^
+-D USE_OCCT_UTILS:BOOL=TRUE ^
+-D GBS_BUILD_TESTS:BOOL=TRUE ^
+-D USE_RENDER:BOOL=FALSE ^
+-D USE_PYTHON_BINDINGS=TRUE ^
+-D CMAKE_INSTALL_PREFIX=%CONDA_PREFIX%/Library ^
+-G "Ninja" ^
 -Wno-dev
 
 ninja install
-@REM ninja
 
-mkdir %SP_DIR%\pygbs
-copy python\pygbs.exp %SP_DIR%\pygbs
-copy python\pygbs.lib %SP_DIR%\pygbs
+cd ..

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,5 @@
-mkdir build
-cd build
+mkdir build-conda
+cd build-conda
 
 cmake .. ^
 -D CMAKE_BUILD_TYPE:STRING="Release" ^
@@ -7,7 +7,7 @@ cmake .. ^
 -D GBS_BUILD_TESTS:BOOL=TRUE ^
 -D USE_RENDER:BOOL=FALSE ^
 -D USE_PYTHON_BINDINGS=TRUE ^
--D CMAKE_INSTALL_PREFIX=%CONDA_PREFIX%/Library ^
+-D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
 -G "Ninja" ^
 -Wno-dev
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,32 +9,20 @@ source:
 build:
 requirements:
   build:
-    - vs2017_win-64
+    - {{ compiler('cxx') }}
+    - ninja
+    - cmake  
   host:
     - python
-    # - vc >=14.1 [win]
-    # - vs2015_runtime >=14.16 [win]
-    # - vs2017_win-64 [win]
-    - {{ compiler('cxx') }}
-    # - {{ compiler('cxx') }} [linux]
-    # - xorg-libxi [linux]
-    # - xorg-libxmu [linux]
-    # - xorg-libxext [linux]
-    # - xorg-libx11 [linux]
-    # - mesa-libgl-devel-cos6-x86_64 [linux]
-    # - make [linux]
-    - ninja
-    - cmake
     - pybind11
+    - occt >=7.4.0
     - nlopt
     - vtk >=9.0
     - eigen
     - boost >=1.74
     - gtest
-    - sundials
-    - occt >=7.4.0
+    - sundials 
   run:
-    - vs2015_runtime  [win]
     - python
     - pytest
     - boost >=1.74

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,22 +1,17 @@
 cmake_minimum_required(VERSION 3.17.0)
 
 project(gbslib_tests LANGUAGES CXX)
-#
+
 # gslib
-#
-# message(gbslib_tests inc ${CMAKE_CURRENT_SOURCE_DIR}/../)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-#
+include_directories(${CMAKE_SOURCE_DIR})
+
 # gbs-occt
-#
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../gbs-occt)
+include_directories(${CMAKE_SOURCE_DIR}/gbs-occt)
 
 file(GLOB SRC_LIST "tests_*")
-message(${SRC_LIST})
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 
 target_link_libraries(${PROJECT_NAME} 
-
                             optimized gtest_dll
                             debug gtest_dlld
                             ${OpenCASCADE_LIBRARIES} 
@@ -25,11 +20,9 @@ target_link_libraries(${PROJECT_NAME}
                             nlopt
                             ${VTK_LIBRARIES}
                             gbs-render
-                    )
+                        )
 
-if ( MSVC )
-    SET_OUT_DIR(${PROJECT_NAME} ${CMAKE_BINARY_DIR})
-endif ( MSVC )
+install(TARGETS ${PROJECT_NAME})
 
 vtk_module_autoinit(
         TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
Hi!

Related to [this issue](https://github.com/ssg-aero/gbs/issues/4#issue-720695354) talking about simplified CMakeLists files

- use GNUInstallDirs
- use build dir even for conda
- fix typo for python bindings
- fix missing vtk module
- add a gitignore