### PR TITLE
Compatibility with `gcc<11.2`

### DIFF
--- a/gbs-mesh/tfi.h
+++ b/gbs-mesh/tfi.h
@@ -140,7 +140,7 @@ namespace gbs
             nui.begin(),
             [&crv_lst,dm](auto u1, auto u2)
             {
-                auto l = std::reduce(
+                auto l = std::accumulate(
                     crv_lst.begin(),crv_lst.end(),T{},
                     // https://en.cppreference.com/w/cpp/algorithm/reduce
                     // The behavior is non-deterministic if binary_op is not associative or not commutative. 
@@ -223,7 +223,7 @@ namespace gbs
         size_t n
         ) -> std::vector<size_t>
     {
-        auto l = std::reduce(
+        auto l = std::accumulate(
             crv_lst.begin(),crv_lst.end(),T{},
             // https://en.cppreference.com/w/cpp/algorithm/reduce
             // The behavior is non-deterministic if binary_op is not associative or not commutative. 
@@ -249,7 +249,7 @@ namespace gbs
         size_t n
         ) -> std::vector<size_t>
     {
-        auto l = std::reduce(
+        auto l = std::accumulate(
             crv_lst.begin(),crv_lst.end(),T{},
             // https://en.cppreference.com/w/cpp/algorithm/reduce
             // The behavior is non-deterministic if binary_op is not associative or not commutative. 


### PR DESCRIPTION
Description
---

Related to downstream project `yams` [issue](https://github.com/ssg-aero/yams/issues/5#issue-1293092364).

Fix `gcc<11.2` compilation error due to `std::reduce` buggy implementation when using the binary functor overload (on static assertion).
- use `std::accumulate` instead of `std::reduce` to workaround the issue
- see [gcc bug tracker](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95833) for more details