### PR TITLE
feat(topology): 2D Constrained Delaunay Triangulation

### DIFF
--- a/inc/topology/edgeRecovery.h
+++ b/inc/topology/edgeRecovery.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "halfEdgeMeshData.h"
+#include "halfEdgeMeshGetters.h"
+#include "halfEdgeMeshEditors.h"
+#include "baseGeom.h"
+#include "baseIntersection.h"
+
+#include <list>
+#include <memory>
+
+namespace gbs
+{
+
+/**
+ * @brief Recovers the constrained edge (v_p, v_q) in a 2D triangulation by
+ *        flipping the diagonals of triangles crossed by the segment p-q.
+ *
+ * Implements the Anglada / Sloan edge-recovery step of a Constrained
+ * Delaunay Triangulation. Assumes the input triangulation already contains
+ * v_p and v_q as vertices, and that the segment p-q does not pass through
+ * any other vertex of the triangulation (no Steiner-point handling here).
+ *
+ * @tparam T Floating-point type.
+ * @param faces_lst Triangulation face list (will be mutated in place).
+ * @param v_p Origin vertex of the constrained edge.
+ * @param v_q End vertex of the constrained edge.
+ * @param tol Tolerance forwarded to seg_seg_strict_intersection / orient_2d.
+ * @return Shared pointer to the half-edge from v_p to v_q after recovery,
+ *         or nullptr on failure (boundary hit, degenerate input, no progress).
+ */
+    template <std::floating_point T>
+    auto recoverEdge(
+        auto& faces_lst,
+        const std::shared_ptr<HalfEdgeVertex<T, 2>>& v_p,
+        const std::shared_ptr<HalfEdgeVertex<T, 2>>& v_q,
+        T tol = T{1e-10}) -> std::shared_ptr<HalfEdge<T, 2>>
+    {
+        if (!v_p || !v_q || v_p == v_q)
+            return nullptr;
+
+        // Edge already present? Cheap fast path.
+        if (auto e = findHalfEdge(v_p, v_q))
+            return e;
+        if (auto e = findHalfEdge(v_q, v_p))
+            return e->opposite ? e->opposite : nullptr;
+
+        const auto& p = v_p->coords;
+        const auto& q = v_q->coords;
+
+        // Step 1: collect the chain of half-edges of `faces_lst` whose interior
+        // is strictly crossed by segment p-q. We start from a face attached to
+        // v_p whose opposite-to-v_p edge crosses p-q, then walk through
+        // successive faces by following the opposite half-edge.
+        std::list<std::shared_ptr<HalfEdge<T, 2>>> crossing;
+
+        for (const auto& f : getFacesAttachedToVertex(v_p))
+        {
+            // The triangle's three edges; pick the one not incident to v_p.
+            for (const auto& e : getTriangleEdges(f))
+            {
+                if (e->vertex == v_p || e->previous->vertex == v_p)
+                    continue;
+                const auto& a = e->previous->vertex->coords;
+                const auto& b = e->vertex->coords;
+                if (seg_seg_strict_intersection(p, q, a, b, tol))
+                {
+                    crossing.push_back(e);
+                    break;
+                }
+            }
+            if (!crossing.empty())
+                break;
+        }
+
+        if (crossing.empty())
+            return nullptr;
+
+        // Walk the chain across opposite half-edges until we reach v_q.
+        // The cap is generous enough for any reasonable polygon while still
+        // failing fast when the navigation has broken.
+        constexpr int max_chain_steps = 4096;
+        for (int step = 0; step < max_chain_steps; ++step)
+        {
+            auto e = crossing.back();
+            if (!e->opposite)
+                return nullptr; // chain hit the mesh boundary
+
+            auto e_in = e->opposite;        // same edge, viewed from the next face
+            auto apex = e_in->next->vertex; // vertex of next face not on the shared edge
+
+            if (apex == v_q)
+                break; // segment p-q ends at this face's apex — chain complete
+
+            auto e_left  = e_in->next;     // from v_a (= e->vertex) to apex
+            auto e_right = e_in->previous; // from apex to v_b (= e->previous->vertex)
+
+            const auto& la = e_left->previous->vertex->coords;
+            const auto& lb = e_left->vertex->coords;
+            const auto& ra = e_right->previous->vertex->coords;
+            const auto& rb = e_right->vertex->coords;
+
+            if (seg_seg_strict_intersection(p, q, la, lb, tol))
+                crossing.push_back(e_left);
+            else if (seg_seg_strict_intersection(p, q, ra, rb, tol))
+                crossing.push_back(e_right);
+            else
+                return nullptr; // p-q passes through a vertex (unsupported here)
+        }
+
+        // Step 2: Anglada — flip each crossing diagonal whose quadrilateral is
+        // convex; non-convex quads are skipped and revisited on the next pass.
+        // Each successful flip either yields the target edge p-q, removes the
+        // diagonal from the crossing list (if it no longer crosses p-q), or
+        // replaces the diagonal in-place (the recycled half-edge is now the new
+        // diagonal between the two former apexes).
+        std::shared_ptr<HalfEdge<T, 2>> recovered{};
+
+        const std::size_t hard_cap = crossing.size() * crossing.size() + 8;
+        for (std::size_t pass = 0; !crossing.empty() && pass < hard_cap; ++pass)
+        {
+            bool any_flipped = false;
+            auto it = crossing.begin();
+            while (it != crossing.end())
+            {
+                auto e = *it;
+                if (!e->opposite)
+                {
+                    it = crossing.erase(it);
+                    continue;
+                }
+                auto f1 = e->face;
+                auto f2 = e->opposite->face;
+
+                // Quad corners: shared edge from v_a to v_b, apex of f1, apex of f2.
+                auto v_a     = e->previous->vertex;
+                auto v_b     = e->vertex;
+                auto v_apex1 = e->next->vertex;
+                auto v_apex2 = e->opposite->next->vertex;
+
+                // Convex iff the alternative splitting (apex1 - apex2) lies inside
+                // the quad: both half-quads must be CCW.
+                const auto& A = v_a->coords;
+                const auto& B = v_b->coords;
+                const auto& C = v_apex1->coords;
+                const auto& D = v_apex2->coords;
+                if (orient_2d(C, B, D) <= tol || orient_2d(D, A, C) <= tol)
+                {
+                    ++it;
+                    continue; // non-convex or degenerate, defer
+                }
+
+                flip(f1, f2);
+
+                // After flip, e is recycled into the new diagonal between the apexes.
+                auto na = e->previous->vertex;
+                auto nb = e->vertex;
+
+                if ((na == v_p && nb == v_q) || (na == v_q && nb == v_p))
+                {
+                    recovered = (na == v_p) ? e : e->opposite;
+                    it = crossing.erase(it);
+                }
+                else if (seg_seg_strict_intersection(
+                             p, q, na->coords, nb->coords, tol))
+                {
+                    ++it; // still crossing — keep, will retry
+                }
+                else
+                {
+                    it = crossing.erase(it);
+                }
+                any_flipped = true;
+            }
+            if (!any_flipped)
+                return nullptr; // stuck — every remaining quad is non-convex
+        }
+
+        if (!recovered)
+            recovered = findHalfEdge(v_p, v_q);
+
+        return recovered;
+    }
+
+} // namespace gbs

--- a/inc/topology/halfEdgeMeshEditors.h
+++ b/inc/topology/halfEdgeMeshEditors.h
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <algorithm>
+#include <unordered_set>
 #include <gbs/execution.h>
 #include <random>
 #include <limits>
@@ -138,6 +139,15 @@ namespace gbs
 
         associate(h_v4, h_e1_1);
         associate(h_v2, h_e1_2);
+
+        // h_e1_1 and h_e1_2 used to be incoming half-edges of h_v1 and h_v3
+        // respectively. After re-association they no longer end at those
+        // vertices, so any vertex->edge pointer that referenced them is now
+        // stale and would break fan navigation (getFacesAttachedToVertex,
+        // findHalfEdge, ...). Repair by pointing at another incoming edge that
+        // still ends at the affected vertex.
+        if (h_v1->edge == h_e1_1) h_v1->edge = h_e3_2; // h_e3_2 still ends at h_v1
+        if (h_v3->edge == h_e1_2) h_v3->edge = h_e3_1; // h_e3_1 still ends at h_v3
 
         std::list<std::shared_ptr<HalfEdge<T, dim>>> lst1{h_e1_1, h_e3_2, h_e2_1};
         std::list<std::shared_ptr<HalfEdge<T, dim>>> lst2{h_e1_2, h_e3_1, h_e2_2};
@@ -299,6 +309,32 @@ namespace gbs
  * @param vtx A shared pointer to a HalfEdgeVertex object that is to be checked for its presence in the faces.
  * @return size_t The count of faces removed from the list.
  */
+/**
+ * @brief Re-sync every vertex->edge pointer in the mesh to a half-edge that is
+ *        actually present in `faces_lst`.
+ *
+ * `vertex->edge` is set lazily on first half-edge creation and is never
+ * reassigned by edits like `flip` or `remove_faces`, so after structural
+ * changes it can dangle to a half-edge whose face was deleted (or whose
+ * end-vertex was changed by a flip). This helper sweeps the current face list
+ * and points every vertex it sees at one of its incoming half-edges, so fan
+ * navigation (`getFacesAttachedToVertex`, `findHalfEdge`, ...) can rely on it.
+ */
+    template <std::floating_point T, size_t dim>
+    void repairVertexEdges(const auto &faces_lst)
+    {
+        // Clear first so we only keep edges that are still part of a face.
+        std::unordered_set<HalfEdgeVertex<T, dim> *> seen;
+        for (const auto &face : faces_lst)
+        {
+            for (const auto &he : getFaceEdges(face))
+            {
+                if (seen.insert(he->vertex.get()).second)
+                    he->vertex->edge = he;
+            }
+        }
+    }
+
     template <std::floating_point T, size_t dim>
     auto remove_faces(auto &faces_lst, const std::shared_ptr<HalfEdgeVertex<T, dim>> &vtx) -> size_t
     {

--- a/inc/topology/halfEdgeMeshGetters.h
+++ b/inc/topology/halfEdgeMeshGetters.h
@@ -359,8 +359,39 @@ namespace gbs
     }
 
 /**
+ * @brief Finds the half-edge going from vertex `v_from` to vertex `v_to`, if one exists.
+ *
+ * Walks the fan of faces attached to `v_from` and looks, in each face, for the
+ * edge whose previous vertex is `v_from` and whose end vertex is `v_to`.
+ *
+ * @tparam T Floating point type used for coordinates.
+ * @tparam dim Dimension of the half-edge data structure.
+ * @param v_from Origin vertex of the desired half-edge.
+ * @param v_to   End vertex of the desired half-edge.
+ * @return Shared pointer to the matching half-edge, or nullptr if none exists.
+ */
+    template <std::floating_point T, size_t dim>
+    auto findHalfEdge(
+        const std::shared_ptr<HalfEdgeVertex<T, dim>> &v_from,
+        const std::shared_ptr<HalfEdgeVertex<T, dim>> &v_to)
+        -> std::shared_ptr<HalfEdge<T, dim>>
+    {
+        if (!v_from || !v_to || !v_from->edge)
+            return nullptr;
+
+        for (const auto &face : getFacesAttachedToVertex(v_from))
+        {
+            // getFaceEdge returns the edge ending at v_from; its `next` starts at v_from.
+            auto incoming = getFaceEdge(face, v_from);
+            if (incoming && incoming->next && incoming->next->vertex == v_to)
+                return incoming->next;
+        }
+        return nullptr;
+    }
+
+/**
  * @brief Gets the list of neighboring faces of a given face.
- * 
+ *
  * @tparam T Floating point type used for coordinates.
  * @tparam dim Dimension of the half-edge data structure.
  * @param h_f Shared pointer to the face.

--- a/inc/topology/tessellations.h
+++ b/inc/topology/tessellations.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <span>
+#include <unordered_set>
 
 #include <gbs/surfaces>
 #include <gbs/bscanalysis.h>
@@ -16,6 +17,7 @@
 #include "baseIntersection.h"
 #include "halfEdgeMeshGeomTests.h"
 #include "halfEdgeMeshSmoothing.h"
+#include "edgeRecovery.h"
 #include "baseGeom.h"
 
 namespace gbs
@@ -167,6 +169,142 @@ namespace gbs
     auto delaunay2DBoyerWatson(const std::vector< std::array<T,2> > &coords, T tol = 1e-10)
     {
         return delaunay2DBoyerWatson<T,std::vector< std::array<T,2> >>(coords, tol);
+    }
+
+/**
+ * @brief Computes a 2D Constrained Delaunay Triangulation (CDT) of a CCW polygon.
+ *
+ * The input is a closed simple polygon, given as its vertices in CCW order
+ * (closure is implicit — do not repeat the first vertex). The function:
+ *   1. builds a Boyer-Watson Delaunay triangulation of the vertices,
+ *   2. recovers each polygon edge by edge-flipping (Anglada / Sloan),
+ *   3. flood-fills from each constrained half-edge and keeps only the faces
+ *      that lie on the interior side (left of every CCW polygon edge).
+ *
+ * Holes and arbitrary internal constraints are not handled in this first cut.
+ * The polygon must be simple (no self-intersection) and no polygon edge may
+ * pass through a non-incident vertex.
+ *
+ * @tparam T Floating-point type.
+ * @param coords Polygon vertices in CCW order.
+ * @param tol Numerical tolerance.
+ * @return Face list of the interior triangles.
+ */
+    template <std::floating_point T>
+    auto delaunay2DConstrained(
+        const std::vector<std::array<T, 2>> &outer,
+        const std::vector<std::vector<std::array<T, 2>>> &holes,
+        T tol = T{1e-10})
+    {
+        // Each polygon ring is described by a vector of vertices in domain-CCW
+        // order: the outer polygon walks CCW around the domain; each hole, as
+        // a polygon, is also CCW around itself, but its domain-interior side
+        // is OUTSIDE the hole. To get a uniform "interior is always on the
+        // left of every constrained edge" invariant — which the flood-fill
+        // below relies on — we walk holes in reverse (CW around themselves =
+        // CCW around the domain region they bound).
+        std::vector<std::vector<std::array<T, 2>>> rings;
+        rings.reserve(holes.size() + 1);
+        rings.push_back(outer);
+        for (const auto &h : holes)
+        {
+            rings.push_back({h.rbegin(), h.rend()});
+        }
+
+        // 1. Boyer-Watson on all ring vertices, tracking which vertex was
+        //    created at each insertion so we can name boundary edges later.
+        std::vector<std::array<T, 2>> all_coords;
+        std::size_t total = 0;
+        for (const auto &r : rings) total += r.size();
+        all_coords.reserve(total);
+        for (const auto &r : rings)
+            all_coords.insert(all_coords.end(), r.begin(), r.end());
+
+        auto faces_lst = getEncompassingMesh(all_coords);
+        auto super_vertices = getVerticesVectorFromFaces<T, 2>(faces_lst);
+
+        std::vector<std::vector<std::shared_ptr<HalfEdgeVertex<T, 2>>>> ring_vtx(rings.size());
+        for (std::size_t r = 0; r < rings.size(); ++r)
+        {
+            ring_vtx[r].resize(rings[r].size());
+            for (std::size_t i = 0; i < rings[r].size(); ++i)
+            {
+                auto [vtx, deleted, created] = boyerWatson<T>(faces_lst, rings[r][i], tol);
+                ring_vtx[r][i] = vtx;
+            }
+        }
+
+        for (const auto &vtx : super_vertices)
+            remove_faces(faces_lst, vtx);
+        // remove_faces only severs opposite linkages; vertex->edge pointers can
+        // still reference half-edges whose face was deleted. Re-sync them
+        // before any navigation (recoverEdge, findHalfEdge) runs.
+        repairVertexEdges<T, 2>(faces_lst);
+
+        // 2. Recover constrained edges (outer + holes); collect both directions
+        //    of each in a set so the flood-fill can refuse to cross them.
+        std::unordered_set<HalfEdge<T, 2> *> constrained;
+        for (const auto &vtx : ring_vtx)
+        {
+            const std::size_t n = vtx.size();
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                auto v_p = vtx[i];
+                auto v_q = vtx[(i + 1) % n];
+                if (!v_p || !v_q) continue;
+                if (auto e = recoverEdge<T>(faces_lst, v_p, v_q, tol))
+                {
+                    constrained.insert(e.get());
+                    if (e->opposite)
+                        constrained.insert(e->opposite.get());
+                }
+            }
+        }
+
+        // 3. Flood-fill interior. Seed with each ring half-edge's left face
+        //    (CCW orientation ⇒ domain interior on the left of every
+        //    constrained edge — true for the outer ring and, after the
+        //    reversal above, for each hole as well).
+        std::unordered_set<HalfEdgeFace<T, 2> *> interior;
+        std::list<std::shared_ptr<HalfEdgeFace<T, 2>>> queue;
+        for (const auto &vtx : ring_vtx)
+        {
+            const std::size_t n = vtx.size();
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                auto e = findHalfEdge(vtx[i], vtx[(i + 1) % n]);
+                if (!e || !e->face) continue;
+                if (interior.insert(e->face.get()).second)
+                    queue.push_back(e->face);
+            }
+        }
+        while (!queue.empty())
+        {
+            auto f = queue.front();
+            queue.pop_front();
+            for (const auto &ee : getTriangleEdges(f))
+            {
+                if (constrained.count(ee.get())) continue;
+                if (!ee->opposite) continue;
+                auto fn = ee->opposite->face;
+                if (fn && interior.insert(fn.get()).second)
+                    queue.push_back(fn);
+            }
+        }
+
+        // 4. Drop exterior faces (includes faces strictly inside each hole).
+        faces_lst.remove_if([&interior](const auto &f) {
+            return interior.find(f.get()) == interior.end();
+        });
+
+        return faces_lst;
+    }
+
+    /// Convenience overload: simple polygon, no holes.
+    template <std::floating_point T>
+    auto delaunay2DConstrained(const std::vector<std::array<T, 2>> &outer, T tol = T{1e-10})
+    {
+        return delaunay2DConstrained<T>(outer, std::vector<std::vector<std::array<T, 2>>>{}, tol);
     }
 /**
  * @brief Refines a 2D Delaunay triangulation of a surface mesh using the Boyer-Watson algorithm.

--- a/tests/tests_halfedgemesh.cpp
+++ b/tests/tests_halfedgemesh.cpp
@@ -1099,3 +1099,103 @@ TEST(halfEdgeMesh, delaunay2d_mesh_face)
         );
     }
 }
+
+TEST(halfEdgeMesh, delaunay2DConstrained_square)
+{
+    using T = double;
+    // Unit square, 4 vertices, CCW.
+    std::vector<std::array<T, 2>> coords{
+        {0., 0.}, {1., 0.}, {1., 1.}, {0., 1.}
+    };
+
+    auto faces_lst = delaunay2DConstrained<T>(coords);
+
+    ASSERT_EQ(faces_lst.size(), 2u);
+    ASSERT_NEAR(getTriangle2dMeshArea(faces_lst), 1.0, 1e-12);
+    for (const auto &hf : faces_lst)
+    {
+        ASSERT_TRUE(is_ccw(hf));
+    }
+}
+
+TEST(halfEdgeMesh, delaunay2DConstrained_L_shape)
+{
+    using T = double;
+    // L-shape, 6 vertices, CCW. Concave: convex-hull contains the notch
+    // that the constrained-Delaunay must cut away.
+    std::vector<std::array<T, 2>> coords{
+        {0., 0.}, {2., 0.}, {2., 1.}, {1., 1.}, {1., 2.}, {0., 2.}
+    };
+
+    auto faces_lst = delaunay2DConstrained<T>(coords);
+
+    // Area = 2*1 + 1*1 = 3.
+    ASSERT_NEAR(getTriangle2dMeshArea(faces_lst), 3.0, 1e-10);
+
+    for (const auto &hf : faces_lst)
+    {
+        ASSERT_TRUE(is_ccw(hf));
+    }
+}
+
+TEST(halfEdgeMesh, delaunay2DConstrained_non_convex_boundary)
+{
+    using T = double;
+    // Same complex zigzag polygon as delaunay2d_non_convex_boundary, but
+    // with non-densified vertices — the CDT must recover concave edges
+    // that the convex-hull triangulation cuts straight across.
+    auto coords = make_boundary2d_3<T>(1.);
+
+    auto faces_lst = delaunay2DConstrained<T>(coords);
+
+    ASSERT_NEAR(getTriangle2dMeshArea(faces_lst), 6.5, 1e-6);
+    for (const auto &hf : faces_lst)
+    {
+        ASSERT_TRUE(is_ccw(hf));
+    }
+}
+
+TEST(halfEdgeMesh, delaunay2DConstrained_square_with_square_hole)
+{
+    using T = double;
+    // Outer 10x10 square (CCW), one inner 2x2 square hole (CCW).
+    // Domain area = 100 - 4 = 96.
+    std::vector<std::array<T, 2>> outer{
+        {0., 0.}, {10., 0.}, {10., 10.}, {0., 10.}
+    };
+    std::vector<std::vector<std::array<T, 2>>> holes{
+        {{4., 4.}, {6., 4.}, {6., 6.}, {4., 6.}}
+    };
+
+    auto faces_lst = delaunay2DConstrained<T>(outer, holes);
+
+    ASSERT_NEAR(getTriangle2dMeshArea(faces_lst), 96.0, 1e-10);
+    for (const auto &hf : faces_lst)
+    {
+        ASSERT_TRUE(is_ccw(hf));
+    }
+}
+
+TEST(halfEdgeMesh, delaunay2DConstrained_plus_shape)
+{
+    using T = double;
+    // "+" sign — 12-vertex polygon, area = 5.
+    // Convex hull is the bounding 3x3 square corners, so the 4 inward
+    // corners (concave) sit STRICTLY INSIDE the hull. Several polygon
+    // edges leading into those concavities must be recovered by flipping
+    // diagonals that the unconstrained Boyer-Watson Delaunay placed
+    // across the inward corners.
+    std::vector<std::array<T, 2>> coords{
+        {1, 0}, {2, 0}, {2, 1}, {3, 1},
+        {3, 2}, {2, 2}, {2, 3}, {1, 3},
+        {1, 2}, {0, 2}, {0, 1}, {1, 1}
+    };
+
+    auto faces_lst = delaunay2DConstrained<T>(coords);
+
+    ASSERT_NEAR(getTriangle2dMeshArea(faces_lst), 5.0, 1e-10);
+    for (const auto &hf : faces_lst)
+    {
+        ASSERT_TRUE(is_ccw(hf));
+    }
+}


### PR DESCRIPTION
## Summary
- New `delaunay2DConstrained(outer, [holes,] tol)` in `inc/topology/tessellations.h`. Boyer-Watson Delaunay → Sloan/Anglada edge recovery (with deferred flipping for non-convex quads) → flood-fill from each constrained half-edge's left face (CCW interior). Holes are reversed internally so the same "interior on the left" invariant applies and the flood-fill naturally excludes hole interiors.
- Building blocks: `findHalfEdge(v_from, v_to)` in halfEdgeMeshGetters.h, `recoverEdge` in new `inc/topology/edgeRecovery.h`, `repairVertexEdges` helper for stale `vertex->edge` after edits.
- Bug fix in `flip` (halfEdgeMeshEditors.h): when the flipped half-edge was the one stored as `vertex->edge`, that pointer became stale and broke fan navigation (`getFacesAttachedToVertex`, `findHalfEdge`, …). Now the affected vertex is repointed at another incoming edge.

## Test plan
- [x] `tests_halfedgemesh` adds 5 cases: square, L-shape, complex zigzag, plus-shape (forces edge-recovery flips through concave corners), square-with-square-hole (area = 96 on a 10×10 with a 2×2 hole).
- [x] Full `tests_halfedgemesh` suite stays green (17/17).
- [x] Consumed downstream by quadsmith's medial-axis hole support, validated end-to-end on real STEP plates.