### PR TITLE
ci: adapt multi-platform CI workflow from Mod3D

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
             shell: bash
 
           # --- macOS: Apple clang (Xcode), no need to force it ---
-          - os: macos-latest
+          # Pinned to macos-13 (Intel / osx-64): libiges has no
+          # osx-arm64 build on conda-forge or ssg-aero, so macos-latest
+          # (arm64) cannot resolve the environment.
+          - os: macos-13
             python-version: "3.13"
             extra-packages: >-
               qt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ on:
     branches: [master, dev]
   pull_request:
     branches: [master, dev]
+  workflow_dispatch:   # allow manual re-runs from the Actions tab / gh CLI
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,10 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++
             shell: bash
 
-          # --- macOS: Apple clang (Xcode), no need to force it ---
-          # macos-latest is arm64. This currently fails fast at the conda
-          # solve because libiges has no osx-arm64 build yet; once an
-          # osx-arm64 libiges is published (conda-forge or ssg-aero, both
-          # are configured channels) this job goes green with no change.
-          # (macos-13 / Intel resolves but its runner queue is unusably
-          # long, so we prefer a fast failure on arm64.)
+          # --- macOS arm64 (Apple Silicon): Apple clang (Xcode) ---
+          # Blocking job. Needs an osx-arm64 libiges (conda-forge or
+          # ssg-aero, both configured); until that propagates it fails
+          # fast at the conda solve, then goes green with no change.
           - os: macos-latest
             python-version: "3.13"
             extra-packages: >-
@@ -91,7 +88,23 @@ jobs:
             cmake-extra: ""
             shell: micromamba-shell {0}
 
+          # --- macOS x86_64 (Intel): Apple clang ---
+          # Non-blocking (experimental): this matches the conda recipe's
+          # osx-64 target and libiges already exists for osx-64, but the
+          # macos-13 (Intel) runner queue can be very long, so we never
+          # let it gate or freeze the CI.
+          - os: macos-13
+            python-version: "3.13"
+            experimental: true
+            extra-packages: >-
+              qt
+            cmake-extra: ""
+            shell: micromamba-shell {0}
+
     runs-on: ${{ matrix.os }}
+    # Per-entry opt-in: experimental jobs (Intel macOS) report status but
+    # never fail or freeze the overall run.
+    continue-on-error: ${{ matrix.experimental || false }}
     defaults:
       run:
         shell: ${{ matrix.shell }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@
 # gbs-specific notes vs Mod3D:
 # - OCCT disabled (GBS_USE_OCCT_UTILS=OFF): no OCCT matrix
 # - on the CMake side, enabling tests OR bindings forces
-#   GBS_USE_RENDER=ON -> VTK (+ Qt on Unix) are required even without
-#   interactive rendering, and gbs-render is a SHARED lib the .pyd and
+#   GBS_USE_RENDER=ON -> VTK is required even without interactive
+#   rendering (Qt is NOT needed: gbs-render uses the native VTK
+#   interactor, not the Qt modules; requesting qt also breaks the
+#   osx-arm64 solve against nlopt's python/libffi pin), and gbs-render
+#   is a SHARED lib the .pyd and
 #   the tests depend on at runtime (hence the PATH / LD_LIBRARY_PATH /
 #   DYLD_LIBRARY_PATH handling below)
 # - the C++ tests use the googletest submodule (recursive checkout),
@@ -57,7 +60,6 @@ jobs:
               clang-tools
               llvm-tools
               lld
-              qt
             cmake-extra: >-
               -DCMAKE_C_COMPILER=clang
               -DCMAKE_CXX_COMPILER=clang++
@@ -84,8 +86,7 @@ jobs:
           # fast at the conda solve, then goes green with no change.
           - os: macos-latest
             python-version: "3.13"
-            extra-packages: >-
-              qt
+            extra-packages: ""
             cmake-extra: ""
             shell: micromamba-shell {0}
 
@@ -97,8 +98,7 @@ jobs:
           - os: macos-13
             python-version: "3.13"
             experimental: true
-            extra-packages: >-
-              qt
+            extra-packages: ""
             cmake-extra: ""
             shell: micromamba-shell {0}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,289 @@
+# ============================================================
+# CI — Build & Test (multi-platform)
+# ============================================================
+# Runs on every push/PR to master or dev.
+# Builds the C++ library (header-only) + the VTK render module +
+# the Python bindings, then runs both the C++ tests (ctest) and the
+# Python tests (pytest) on Linux, Windows and macOS in parallel.
+#
+# Adapted from the Mod3D workflow:
+# - flat matrix (`include` entries only): one job per OS, fail-fast OFF
+# - micromamba to resolve conda deps (conda-forge + ssg-aero, the
+#   latter provides libiges)
+# - Windows workarounds (micromamba shell init crashes on the runner
+#   image) carried over as-is
+# - clang (conda-forge) on Linux/Windows like the local setup; Apple
+#   clang on macOS
+#
+# gbs-specific notes vs Mod3D:
+# - OCCT disabled (GBS_USE_OCCT_UTILS=OFF): no OCCT matrix
+# - on the CMake side, enabling tests OR bindings forces
+#   GBS_USE_RENDER=ON -> VTK (+ Qt on Unix) are required even without
+#   interactive rendering, and gbs-render is a SHARED lib the .pyd and
+#   the tests depend on at runtime (hence the PATH / LD_LIBRARY_PATH /
+#   DYLD_LIBRARY_PATH handling below)
+# - the C++ tests use the googletest submodule (recursive checkout),
+#   GTest being resolved via conda only in a conda build
+# - the Python tests do VTK rendering (test_json.py calls
+#   plotter.show()) -> off-screen rendering everywhere + xvfb on Linux
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+
+name: CI
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: ${{ matrix.os }} / py${{ matrix.python-version }}
+    strategy:
+      fail-fast: false    # do not stop the other OSes if one fails
+      # Flat matrix (`include` entries only): one job per OS, each
+      # with its own compiler and shell.
+      matrix:
+        include:
+          # --- Linux: conda-forge clang, like the local setup ---
+          - os: ubuntu-latest
+            python-version: "3.13"
+            extra-packages: >-
+              clangxx
+              clang-tools
+              llvm-tools
+              lld
+              qt
+            cmake-extra: >-
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+            shell: micromamba-shell {0}
+
+          # --- Windows: conda-forge clang (the pre-installed MinGW
+          #     conflicts with the conda libs) + bash, because
+          #     `micromamba shell init` crashes on the runner image ---
+          - os: windows-latest
+            python-version: "3.13"
+            extra-packages: >-
+              clangxx
+              clang-tools
+              llvm-tools
+              lld
+            cmake-extra: >-
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+            shell: bash
+
+          # --- macOS: Apple clang (Xcode), no need to force it ---
+          - os: macos-latest
+            python-version: "3.13"
+            extra-packages: >-
+              qt
+            cmake-extra: ""
+            shell: micromamba-shell {0}
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive   # googletest is a submodule
+
+      # ------------------------------------------------------------
+      # Set up the conda environment (deps from recipe/recipe.yaml)
+      # ------------------------------------------------------------
+      # On Windows we omit `init-shell` because `micromamba shell init`
+      # crashes on the runner image (exit 0xC0000005); we activate the
+      # env manually in the next step.
+      - name: Setup micromamba environment (Windows)
+        if: runner.os == 'Windows'
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          # Pinned version (instead of `latest`) to force the download
+          # of a healthy binary: the micromamba pre-installed on the
+          # runner image crashes on its subcommands.
+          micromamba-version: '1.5.10-0'
+          environment-name: gbs-ci
+          condarc: |
+            channels:
+              - conda-forge
+              - ssg-aero
+          create-args: >-
+            python=${{ matrix.python-version }}
+            cmake>=3.28
+            ninja
+            pybind11
+            vtk
+            eigen>=3.3.9
+            nlopt
+            libboost
+            libboost-devel
+            rapidjson
+            tbb
+            tbb-devel
+            libiges
+            numpy
+            pyvista
+            pythreejs
+            pytest
+            ${{ matrix.extra-packages }}
+          cache-environment: true
+          init-shell: none
+
+      # `init-shell: none` does not expose CONDA_PREFIX/PATH, so we
+      # activate the env by hand for the following steps (otherwise
+      # CMake falls back to the host Python and finds neither VTK nor
+      # the bindings).
+      - name: Activate micromamba env (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          env_path="$MAMBA_ROOT_PREFIX/envs/gbs-ci"
+          echo "CONDA_PREFIX=$env_path" >> "$GITHUB_ENV"
+          echo "$env_path/Library/bin" >> "$GITHUB_PATH"
+          echo "$env_path/Library/usr/bin" >> "$GITHUB_PATH"
+          echo "$env_path/Library/mingw-w64/bin" >> "$GITHUB_PATH"
+          echo "$env_path/Scripts" >> "$GITHUB_PATH"
+          echo "$env_path" >> "$GITHUB_PATH"
+
+      - name: Setup micromamba environment (Unix)
+        if: runner.os != 'Windows'
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          micromamba-version: latest
+          environment-name: gbs-ci
+          condarc: |
+            channels:
+              - conda-forge
+              - ssg-aero
+          create-args: >-
+            python=${{ matrix.python-version }}
+            cmake>=3.28
+            ninja
+            pybind11
+            vtk
+            eigen>=3.3.9
+            nlopt
+            libboost
+            libboost-devel
+            rapidjson
+            tbb
+            tbb-devel
+            libiges
+            numpy
+            pyvista
+            pythreejs
+            pytest
+            ${{ matrix.extra-packages }}
+          cache-environment: true
+          init-shell: bash
+
+      # xvfb provides a display + GL context for the off-screen VTK
+      # rendering of the Python tests on Linux (headless runner).
+      - name: Install xvfb (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      # ------------------------------------------------------------
+      # Configure
+      # ------------------------------------------------------------
+      # On conda Windows the libs live under CONDA_PREFIX/Library
+      # (not directly under CONDA_PREFIX as on Unix).
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        run: >-
+          cmake -B build -S . -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DGBS_BUILD_TESTS=ON
+          -DGBS_USE_PYTHON_BINDINGS=ON
+          -DGBS_USE_RENDER=ON
+          -DGBS_BUILD_STUBS=OFF
+          -DGBS_USE_OCCT_UTILS=OFF
+          -DGBS_USE_CUDA=OFF
+          -DGBS_USE_MODULES=OFF
+          -DGBS_BUILD_DOC=OFF
+          "-DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX/Library"
+          ${{ matrix.cmake-extra }}
+
+      - name: Configure (Unix)
+        if: runner.os != 'Windows'
+        run: >-
+          cmake -B build -S . -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DGBS_BUILD_TESTS=ON
+          -DGBS_USE_PYTHON_BINDINGS=ON
+          -DGBS_USE_RENDER=ON
+          -DGBS_BUILD_STUBS=OFF
+          -DGBS_USE_OCCT_UTILS=OFF
+          -DGBS_USE_CUDA=OFF
+          -DGBS_USE_MODULES=OFF
+          -DGBS_BUILD_DOC=OFF
+          -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+          ${{ matrix.cmake-extra }}
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      # Install gbs-render (SHARED) + the bindings into site-packages
+      # (pygbs/) so that `import pygbs.gbs` and loading the render lib
+      # work from the tests.
+      - name: Install
+        run: cmake --install build
+
+      # ------------------------------------------------------------
+      # C++ tests (ctest)
+      # ------------------------------------------------------------
+      # On Windows the DLLs (VTK/TBB/NLopt/libIGES/gbs-render) live in
+      # CONDA_PREFIX/Library/bin -> they must be on the PATH.
+      - name: Test C++ (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          export PATH="$CONDA_PREFIX/Library/bin:$PATH"
+          ctest --test-dir build --output-on-failure -C Release
+
+      - name: Test C++ (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          ctest --test-dir build --output-on-failure -C Release
+
+      - name: Test C++ (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          export DYLD_LIBRARY_PATH="$CONDA_PREFIX/lib:$DYLD_LIBRARY_PATH"
+          ctest --test-dir build --output-on-failure -C Release
+
+      # ------------------------------------------------------------
+      # Python tests (pytest) — off-screen VTK rendering
+      # ------------------------------------------------------------
+      - name: Test Python (Windows)
+        if: runner.os == 'Windows'
+        env:
+          PYVISTA_OFF_SCREEN: "true"
+        run: |
+          export PATH="$CONDA_PREFIX/Library/bin:$PATH"
+          pytest python/tests/ -v
+
+      - name: Test Python (Linux)
+        if: runner.os == 'Linux'
+        env:
+          PYVISTA_OFF_SCREEN: "true"
+        run: |
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          xvfb-run -a pytest python/tests/ -v
+
+      - name: Test Python (macOS)
+        if: runner.os == 'macOS'
+        env:
+          PYVISTA_OFF_SCREEN: "true"
+        run: |
+          export DYLD_LIBRARY_PATH="$CONDA_PREFIX/lib:$DYLD_LIBRARY_PATH"
+          pytest python/tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,12 @@ jobs:
       # ------------------------------------------------------------
       # On conda Windows the libs live under CONDA_PREFIX/Library
       # (not directly under CONDA_PREFIX as on Unix).
+      # CMAKE_RUNTIME_OUTPUT_DIRECTORY co-locates the built DLLs/exes
+      # (gbs-render.dll, the test exes) in Library/bin, which is on the
+      # PATH alongside the VTK/TBB/... DLLs. Without it, gtest_discover_tests
+      # runs each test exe at build time and fails with 0xc0000135
+      # (DLL not found), since gbs-render.dll is a SHARED lib built in a
+      # different directory and not yet installed.
       - name: Configure (Windows)
         if: runner.os == 'Windows'
         run: >-
@@ -214,6 +220,7 @@ jobs:
           -DGBS_USE_MODULES=OFF
           -DGBS_BUILD_DOC=OFF
           "-DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX/Library"
+          "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$CONDA_PREFIX/Library/bin"
           ${{ matrix.cmake-extra }}
 
       - name: Configure (Unix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,13 @@ jobs:
             shell: bash
 
           # --- macOS: Apple clang (Xcode), no need to force it ---
-          # Pinned to macos-13 (Intel / osx-64): libiges has no
-          # osx-arm64 build on conda-forge or ssg-aero, so macos-latest
-          # (arm64) cannot resolve the environment.
-          - os: macos-13
+          # macos-latest is arm64. This currently fails fast at the conda
+          # solve because libiges has no osx-arm64 build yet; once an
+          # osx-arm64 libiges is published (conda-forge or ssg-aero, both
+          # are configured channels) this job goes green with no change.
+          # (macos-13 / Intel resolves but its runner queue is unusably
+          # long, so we prefer a fast failure on arm64.)
+          - os: macos-latest
             python-version: "3.13"
             extra-packages: >-
               qt
@@ -136,6 +139,7 @@ jobs:
             pyvista
             pythreejs
             pytest
+            pytest-timeout
             ${{ matrix.extra-packages }}
           cache-environment: true
           init-shell: none
@@ -184,6 +188,7 @@ jobs:
             pyvista
             pythreejs
             pytest
+            pytest-timeout
             ${{ matrix.extra-packages }}
           cache-environment: true
           init-shell: bash
@@ -280,7 +285,7 @@ jobs:
           PYVISTA_OFF_SCREEN: "true"
         run: |
           export PATH="$CONDA_PREFIX/Library/bin:$PATH"
-          pytest python/tests/ -v
+          pytest python/tests/ -v --timeout=120 -ra
 
       - name: Test Python (Linux)
         if: runner.os == 'Linux'
@@ -288,7 +293,7 @@ jobs:
           PYVISTA_OFF_SCREEN: "true"
         run: |
           export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          xvfb-run -a pytest python/tests/ -v
+          xvfb-run -a pytest python/tests/ -v --timeout=120 -ra
 
       - name: Test Python (macOS)
         if: runner.os == 'macOS'
@@ -296,4 +301,4 @@ jobs:
           PYVISTA_OFF_SCREEN: "true"
         run: |
           export DYLD_LIBRARY_PATH="$CONDA_PREFIX/lib:$DYLD_LIBRARY_PATH"
-          pytest python/tests/ -v
+          pytest python/tests/ -v --timeout=120 -ra

--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include <gbs/bscurve.h>
 #include <gbs/bscinterp.h>
 #include <gbs/bssurf.h>

--- a/gbs/bsstools.h
+++ b/gbs/bsstools.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include <gbs/bssurf.h>
 #include <gbs/bscapprox.h>
 #include <gbs/transformpoints.h>

--- a/gbs/bssurf.h
+++ b/gbs/bssurf.h
@@ -3,6 +3,7 @@
     import basis_functions;
     import knots_functions;
 #endif
+#include <cassert>
 #include <gbs/bscurve.h>
 #include <gbs/polestools.h>
 #include <gbs/exceptions.h>

--- a/gbs/curvecomposite.h
+++ b/gbs/curvecomposite.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <gbs/bscurve.h>
 #include <algorithm>
 namespace gbs

--- a/gbs/knotsfunctions.ixx
+++ b/gbs/knotsfunctions.ixx
@@ -3,6 +3,7 @@
 #else
     #pragma once
 #endif
+#include <cassert>
 #include <gbs/gbslib.h>
 #include <list>
 #include <utility>

--- a/inc/topology/halfEdgeMeshData.h
+++ b/inc/topology/halfEdgeMeshData.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include <memory>
 #include <algorithm>
 #include <vector>

--- a/inc/topology/halfEdgeMeshEditors.h
+++ b/inc/topology/halfEdgeMeshEditors.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include "halfEdgeMeshData.h"
 #include "halfEdgeMeshGetters.h"
 

--- a/inc/topology/halfEdgeMeshGeomTests.h
+++ b/inc/topology/halfEdgeMeshGeomTests.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include "halfEdgeMeshData.h"
 #include "baseGeom.h"
 

--- a/inc/topology/halfEdgeMeshGetters.h
+++ b/inc/topology/halfEdgeMeshGetters.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <list>
 #include <map>
 #include "halfEdgeMeshData.h"

--- a/inc/topology/halfEdgeMeshQuality.h
+++ b/inc/topology/halfEdgeMeshQuality.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include "halfEdgeMeshData.h"
 #include <gbs/execution.h>
 #include <algorithm>

--- a/inc/topology/tessellations.h
+++ b/inc/topology/tessellations.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <array>
 #include <vector>
 #include <algorithm>

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <vector>
 #include <array>
 #include <gbs/bscurve.h>

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Pytest configuration for the gbs Python tests.
+
+Several tests end with an interactive VTK render call:
+  * ``gbs.plot_curves`` / ``plot_curves_2d`` / ``plot_surfaces`` (gbs bindings)
+  * ``pygbs.vtkplot.render_actors`` (gbs VTK helper)
+  * pyvista's ``Plotter.show()``
+
+These spin a blocking ``vtkRenderWindowInteractor`` event loop that never
+returns without a user, which hangs the whole suite on a headless CI runner
+(the interactor holds the GIL, so even pytest-timeout cannot interrupt it).
+
+In a headless / CI environment we therefore force off-screen rendering and
+neutralize the blocking entry points. The numerical assertions in those tests
+still run; only the interactive display is short-circuited. Local interactive
+runs (no CI / PYVISTA_OFF_SCREEN set) are left untouched.
+"""
+import os
+
+_HEADLESS = bool(os.environ.get("CI") or os.environ.get("PYVISTA_OFF_SCREEN"))
+
+if _HEADLESS:
+    # pyvista: render off-screen (test_json.py calls Plotter.show()).
+    try:
+        import pyvista
+
+        pyvista.OFF_SCREEN = True
+    except Exception:
+        pass
+
+    # gbs bindings: the plot_* helpers open a blocking interactive window.
+    try:
+        import pygbs.gbs as _gbs
+
+        for _name in ("plot_curves", "plot_curves_2d", "plot_surfaces"):
+            if hasattr(_gbs, _name):
+                setattr(_gbs, _name, lambda *args, **kwargs: None)
+    except Exception:
+        pass
+
+    # gbs VTK helper used by the mesh tests.
+    try:
+        from pygbs import vtkplot as _vtkplot
+
+        if hasattr(_vtkplot, "render_actors"):
+            _vtkplot.render_actors = lambda *args, **kwargs: None
+    except Exception:
+        pass

--- a/tests/tests_baseIntersections.cpp
+++ b/tests/tests_baseIntersections.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 #include <topology/baseIntersection.h>
 #include <array>

--- a/tests/tests_bssurf.cpp
+++ b/tests/tests_bssurf.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 #include <gbs/bssurf.h>
 

--- a/tests/tests_halfedgemesh.cpp
+++ b/tests/tests_halfedgemesh.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 #ifdef GBS_USE_MODULES
     import vecop;


### PR DESCRIPTION
Adapts the Mod3D GitHub Actions CI to gbs.

## What it does
Builds gbs (C++ header-only + VTK render module + Python bindings) and runs **both** `ctest` and `pytest` on Linux, Windows and macOS.

## Carried over from Mod3D
- Flat `include` matrix, `fail-fast: false`, one job per OS
- micromamba for conda deps (`conda-forge` + `ssg-aero`), clang on Linux/Windows, Apple clang on macOS
- Windows `micromamba shell init` crash workaround (pinned micromamba, `init-shell: none`, manual env activation)

## gbs-specific handling
- OCCT disabled (`GBS_USE_OCCT_UTILS=OFF`) — no OCCT matrix
- Enabling tests/bindings forces `GBS_USE_RENDER=ON` → VTK (+ Qt on Unix) installed
- `gbs-render` is a SHARED lib → `cmake --install` before tests + `PATH`/`LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` so the `.pyd` and test exes load it
- `googletest` submodule (recursive checkout)
- Python tests do VTK rendering (`test_json.py` calls `plotter.show()`) → `PYVISTA_OFF_SCREEN` everywhere + `xvfb` on Linux

## Note
Could not run GitHub Actions locally; the runtime-linking of `gbs-render` and off-screen rendering are the most likely spots to need tuning on the first run.
