### PR TITLE
test: deterministic interior points for is_inside_boundary (conda Windows)

### DIFF
--- a/tests/tests_halfedgemesh.cpp
+++ b/tests/tests_halfedgemesh.cpp
@@ -589,7 +589,19 @@ TEST(halfEdgeMesh, is_inside_boundary)
     reverseBoundary(boundary);
     ASSERT_FALSE(are_edges_2d_ccw<T>(boundary));
 
-    add_random_points_ellipse(coords,11);
+    // Fixed interior points instead of add_random_points_ellipse: the boundary
+    // is the ellipse (R=1, r=0.5) sampled into a *polygon* (mesh_wire_uniform),
+    // so a point that is inside the smooth ellipse but near the rim can fall in
+    // the gap between a chord and the arc -> outside the polygon -> is_inside
+    // returns false and the assertions below break. The random points were also
+    // non-portable across STLs (std::uniform_real_distribution differs), which
+    // made this fail only on MSVC/conda. These points sit well inside the
+    // polygon (x^2 + (y/0.5)^2 <= ~0.45, large margin vs the dm=0.1 sagitta).
+    for (const auto &xy : std::vector<std::array<T,2>>{
+            {0.0, 0.0}, {0.5, 0.0}, {-0.5, 0.0}, {0.0, 0.3}, {0.0, -0.3},
+            {0.35, 0.2}, {-0.35, 0.2}, {0.35, -0.2}, {-0.35, -0.2},
+            {0.6, 0.15}, {-0.6, -0.15} })
+        coords.push_back(xy);
 
     // auto faces_lst = delaunay2DBoyerWatson<T>(coords);
 


### PR DESCRIPTION
Follow-up to #25, completing the conda-forge test portability work surfaced by conda-forge/gbs-feedstock#6 (nlopt 2.11 rebuild).

`halfEdgeMesh.is_inside_boundary` still failed on the Windows/conda runner after #25. Root cause:

- The test added points inside the **smooth** ellipse (R=1, r=0.5) but checked them against the boundary **polygon** (`mesh_wire_uniform`). A point near the rim can be inside the ellipse yet **outside** the polygon (the chord/arc gap) -> `is_inside` returns false -> assertion fails.
- `std::uniform_real_distribution` is **not portable** across STLs, so even the seed added in #25 produced different points on MSVC vs libstdc++ -- the failure only appeared on conda's Windows runner (Linux passed).

## Fix
Replace the random points in this one test with a fixed set sitting well inside the polygon (large margin vs the dm=0.1 sagitta). The shared `add_random_points_ellipse` helper is untouched (other tests still use it).

Verified locally on Windows/clang: the test passes.

After merge I'll tag the next release so the feedstock can drop its temporary workaround.
