### PR TITLE
fix(topology): robust is_inside (PNPOLY) — fixes MSVC is_inside_boundary

### DIFF
--- a/inc/topology/halfEdgeMeshGeomTests.h
+++ b/inc/topology/halfEdgeMeshGeomTests.h
@@ -76,27 +76,44 @@ namespace gbs
     template <std::floating_point T, std::ranges::range Container>
     bool is_inside(const std::array<T, 2> &xy, const Container &h_e_lst, T tol = 1e-10)
     {
-        size_t count{};
+        // Even-odd horizontal ray cast (the classic PNPOLY rule). An edge crosses
+        // the ray y = xy[1] iff exactly one endpoint is *strictly* above it; the
+        // intersection abscissa is then compared to xy[0] to count only crossings
+        // on the +x side. The strict-above test classifies a vertex lying on the
+        // ray consistently for the two edges that share it, so a ray grazing a
+        // vertex (e.g. the ellipse centre, whose ray passes through the (R,0)
+        // sample) or a near-horizontal edge no longer flips the parity by a
+        // rounding hair. The previous implementation counted crossings through
+        // seg_H_strict_end_intersection, whose |delta|<tol early-out silently
+        // dropped near-horizontal crossings and whose divisions made the result
+        // depend on the STL/compiler rounding -- is_inside({0,0}) of the boundary
+        // ellipse returned false under MSVC while passing under clang.
+        bool inside = false;
         for (const auto &he : h_e_lst)
         {
             const auto &a = he->previous->vertex->coords;
             const auto &b = he->vertex->coords;
-            
-            // Check if the point is on the polygon's edges
+
+            // A point on the boundary is considered inside.
             if (on_segment(a, b, xy, tol))
             {
                 return true;
             }
-            
-            // Check if the segment intersects with the half-open line segment
-            if (seg_H_strict_end_intersection(a, b, xy, tol))
+
+            const bool a_above = a[1] > xy[1];
+            const bool b_above = b[1] > xy[1];
+            if (a_above != b_above)
             {
-                count++;
+                // Endpoints straddle the ray => b[1]-a[1] != 0, division is safe.
+                const T x_cross = a[0] + (xy[1] - a[1]) * (b[0] - a[0]) / (b[1] - a[1]);
+                if (xy[0] < x_cross)
+                {
+                    inside = !inside;
+                }
             }
         }
 
-        // When count is odd, the point is inside the polygon
-        return count % 2 == 1;
+        return inside;
     }
 /**
  * @brief Determines if a half-edge belongs to a locally Delaunay triangulation.

--- a/tests/tests_halfedgemesh.cpp
+++ b/tests/tests_halfedgemesh.cpp
@@ -689,6 +689,52 @@ TEST(halfEdgeMesh, is_inside_boundary)
     }
 }
 
+// Regression guard for is_inside robustness. The point-in-polygon test casts a
+// horizontal ray and counts crossings; the previous implementation dropped
+// near-horizontal crossings (|y-span| below its 1e-10 tolerance) and relied on
+// divisions that flipped the parity depending on STL/compiler rounding. That is
+// what made halfEdgeMesh.is_inside_boundary fail on MSVC/conda only (the ellipse
+// centre, whose ray grazes the (1,0) sample). These hand-built polygons exercise
+// exactly those degeneracies and must give a stable, orientation-independent
+// answer.
+TEST(halfEdgeMesh, is_inside_robust_degenerate)
+{
+    using T = double;
+    const std::array<T, 2> O{0., 0.};
+
+    auto inside_both_orientations = [&O](std::vector<std::array<T, 2>> coords)
+    {
+        auto boundary = make_HalfEdges(coords);
+        bool ccw = is_inside<T>(O, boundary);
+        reverseBoundary(boundary);
+        bool cw = is_inside<T>(O, boundary);
+        return std::make_pair(ccw, cw);
+    };
+
+    // The only +x crossing is a near-horizontal edge (|y-span| = 5e-11), smaller
+    // than the historical 1e-10 early-out: it used to be dropped -> "outside".
+    {
+        auto [ccw, cw] = inside_both_orientations(
+            {{-1, -1}, {1, -2.5e-11}, {3, 2.5e-11}, {3, 1}, {-1, 1}});
+        ASSERT_TRUE(ccw);
+        ASSERT_TRUE(cw);
+    }
+    // A boundary vertex lies exactly on the ray at (1,0) with a sub-nm sliver
+    // neighbour just below it: the ray grazes the vertex, parity must stay odd.
+    {
+        auto [ccw, cw] = inside_both_orientations(
+            {{-1, -1}, {1, -1}, {1, -1e-12}, {1, 0}, {0.98, 0.1}, {-1, 1}});
+        ASSERT_TRUE(ccw);
+        ASSERT_TRUE(cw);
+    }
+    // A point clearly outside stays outside under the same grazing geometry.
+    {
+        auto boundary = make_HalfEdges(std::vector<std::array<T, 2>>{
+            {-1, -1}, {1, -2.5e-11}, {3, 2.5e-11}, {3, 1}, {-1, 1}});
+        ASSERT_FALSE(is_inside<T>(std::array<T, 2>{5., 0.}, boundary));
+    }
+}
+
 TEST(halfEdgeMesh, delaunay2d_non_convex_boundary)
 {
     using T = double;


### PR DESCRIPTION
fix(topology): make is_inside robust to ray-grazing degeneracies

is_inside cast a +x horizontal ray and counted crossings via
seg_H_strict_end_intersection. That path had two FP fragilities:
its |delta|<tol (1e-10) early-out silently dropped near-horizontal
crossings, and the s>0 / t in [0,1) tests were computed through
divisions whose sign flipped on rounding. As a result the parity --
hence inside/outside -- depended on the STL/compiler: is_inside({0,0})
of the polygonised ellipse boundary (R=1, r=0.5), whose ray grazes the
exact (1,0) sample, returned false under MSVC/conda while passing under
gcc/clang. This is what made halfEdgeMesh.is_inside_boundary fail only
on the conda-forge Windows build.

Replace the crossing count with the canonical even-odd (PNPOLY) rule:
an edge crosses the ray iff exactly one endpoint is strictly above it,
then compare the intersection abscissa to the point. The strict-above
test classifies a vertex on the ray consistently for both edges sharing
it, so grazing a vertex or a near-horizontal edge no longer flips parity
by a rounding hair, and the rule is orientation-independent. The
on-boundary early return (on_segment) is kept.

Add halfEdgeMesh.is_inside_robust_degenerate covering the
near-horizontal crossing and vertex-on-ray + sliver configurations in
both orientations; it fails on the old implementation.

Validated under MSVC (the failing toolchain) on a standalone repro and
with the full halfEdgeMesh suite (19/19) under clang.