### PR TITLE
feat: vectorized curve & surface derivatives w.r.t. curvilinear abscissa

### DIFF
--- a/News.md
+++ b/News.md
@@ -1,7 +1,8 @@
 # GBS Release Notes
 13 jun 2026
 * vectorized curve derivatives w.r.t. curvilinear abscissa (`d_dms` / `d_dm2s`)
-* Python bindings: `d_dm` / `d_dm2` overloads accepting a list of parameters
+* vectorized surface arc-length derivatives (`d_dmus` / `d_dmvs` / `d_dmu2s` / `d_dmv2s`)
+* Python bindings: `d_dm` / `d_dm2` (curves) and `d_dmu` / `d_dmv` / `d_dmu2` / `d_dmv2` (surfaces) overloads accepting a list of parameters
 11 oct 2022
 * surfaces iso parametric curves
 08 mar 2022

--- a/News.md
+++ b/News.md
@@ -1,4 +1,7 @@
 # GBS Release Notes
+13 jun 2026
+* vectorized curve derivatives w.r.t. curvilinear abscissa (`d_dms` / `d_dm2s`)
+* Python bindings: `d_dm` / `d_dm2` overloads accepting a list of parameters
 11 oct 2022
 * surfaces iso parametric curves
 08 mar 2022

--- a/gbs/bscurve.h
+++ b/gbs/bscurve.h
@@ -132,6 +132,44 @@ namespace gbs
             auto cp_cs = d_du * d_du2;      // C' . C''
             return (d_du2 * N - d_du * cp_cs) / (N * N);
         }
+        /**
+         * @brief Curve first derivative w.r.t. the curvilinear abscissa, evaluated over a list of parameters
+         *
+         * @tparam _Container A template template parameter representing the container type.
+         * @tparam Args Additional template arguments for the container (e.g., custom allocators).
+         * @param u_lst A container of parameters at which to evaluate the derivative.
+         * @return points_vector<T, dim>
+         */
+        template <template<typename ...> class _Container, typename... Args>
+        auto d_dms(const _Container<T, Args...> &u_lst) const -> points_vector<T, dim>
+        {
+            points_vector<T, dim> res(u_lst.size());
+            std::transform(
+                u_lst.begin(), u_lst.end(),
+                res.begin(),
+                [this](auto u){return this->d_dm(u);}
+            );
+            return res;
+        }
+        /**
+         * @brief Curve second derivative w.r.t. the curvilinear abscissa, evaluated over a list of parameters
+         *
+         * @tparam _Container A template template parameter representing the container type.
+         * @tparam Args Additional template arguments for the container (e.g., custom allocators).
+         * @param u_lst A container of parameters at which to evaluate the derivative.
+         * @return points_vector<T, dim>
+         */
+        template <template<typename ...> class _Container, typename... Args>
+        auto d_dm2s(const _Container<T, Args...> &u_lst) const -> points_vector<T, dim>
+        {
+            points_vector<T, dim> res(u_lst.size());
+            std::transform(
+                u_lst.begin(), u_lst.end(),
+                res.begin(),
+                [this](auto u){return this->d_dm2(u);}
+            );
+            return res;
+        }
     };
 
     template<typename T>

--- a/gbs/bssurf.h
+++ b/gbs/bssurf.h
@@ -283,6 +283,86 @@ namespace gbs
             auto dot_ = S_v * S_vv;         // S_v . S_vv
             return (S_vv * N - S_v * dot_) / (N * N);
         }
+
+        /**
+         * @brief Unit tangent of the u-iso curve, evaluated over a list of (u, v) parameters.
+         *
+         * @tparam _Container A template template parameter representing the container type.
+         * @tparam Args Additional template arguments for the container (e.g., custom allocators).
+         * @param uv_lst A container of parameter pairs (u, v) at which to evaluate the derivative.
+         * @return points_vector<T, dim>
+         */
+        template <template<typename ...> class _Container, typename... Args>
+        auto d_dmus(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
+        {
+            points_vector<T, dim> res(uv_lst.size());
+            std::transform(
+                uv_lst.begin(), uv_lst.end(),
+                res.begin(),
+                [this](const auto &uv){return this->d_dmu(uv[0], uv[1]);}
+            );
+            return res;
+        }
+
+        /**
+         * @brief Unit tangent of the v-iso curve, evaluated over a list of (u, v) parameters.
+         *
+         * @tparam _Container A template template parameter representing the container type.
+         * @tparam Args Additional template arguments for the container (e.g., custom allocators).
+         * @param uv_lst A container of parameter pairs (u, v) at which to evaluate the derivative.
+         * @return points_vector<T, dim>
+         */
+        template <template<typename ...> class _Container, typename... Args>
+        auto d_dmvs(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
+        {
+            points_vector<T, dim> res(uv_lst.size());
+            std::transform(
+                uv_lst.begin(), uv_lst.end(),
+                res.begin(),
+                [this](const auto &uv){return this->d_dmv(uv[0], uv[1]);}
+            );
+            return res;
+        }
+
+        /**
+         * @brief Second derivative w.r.t. arc length along the u-iso curve, evaluated over a list of (u, v) parameters.
+         *
+         * @tparam _Container A template template parameter representing the container type.
+         * @tparam Args Additional template arguments for the container (e.g., custom allocators).
+         * @param uv_lst A container of parameter pairs (u, v) at which to evaluate the derivative.
+         * @return points_vector<T, dim>
+         */
+        template <template<typename ...> class _Container, typename... Args>
+        auto d_dmu2s(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
+        {
+            points_vector<T, dim> res(uv_lst.size());
+            std::transform(
+                uv_lst.begin(), uv_lst.end(),
+                res.begin(),
+                [this](const auto &uv){return this->d_dmu2(uv[0], uv[1]);}
+            );
+            return res;
+        }
+
+        /**
+         * @brief Second derivative w.r.t. arc length along the v-iso curve, evaluated over a list of (u, v) parameters.
+         *
+         * @tparam _Container A template template parameter representing the container type.
+         * @tparam Args Additional template arguments for the container (e.g., custom allocators).
+         * @param uv_lst A container of parameter pairs (u, v) at which to evaluate the derivative.
+         * @return points_vector<T, dim>
+         */
+        template <template<typename ...> class _Container, typename... Args>
+        auto d_dmv2s(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
+        {
+            points_vector<T, dim> res(uv_lst.size());
+            std::transform(
+                uv_lst.begin(), uv_lst.end(),
+                res.begin(),
+                [this](const auto &uv){return this->d_dmv2(uv[0], uv[1]);}
+            );
+            return res;
+        }
     };
 
     template <std::floating_point T, size_t dim>

--- a/python/gbsBindCurves.h
+++ b/python/gbsBindCurves.h
@@ -133,10 +133,28 @@ inline void gbs_bind_curves(py::module &m)
             "Curve first derivative respectively to the curvilinear abscissa",
             py::arg("m"))
         .def(
+            "d_dm",
+            [](const Curve<T, dim> &self, const std::vector<T> &u_lst)
+            {
+                py::array points = py::cast(self.d_dms(u_lst));
+                return points;
+            },
+            "Curve first derivative w.r.t. the curvilinear abscissa, vectorized over a list of parameters",
+            py::arg("u_lst"))
+        .def(
             "d_dm2",
             &Curve<T, dim>::d_dm2,
             "Curve second derivative respectively to the curvilinear abscissa",
             py::arg("m"))
+        .def(
+            "d_dm2",
+            [](const Curve<T, dim> &self, const std::vector<T> &u_lst)
+            {
+                py::array points = py::cast(self.d_dm2s(u_lst));
+                return points;
+            },
+            "Curve second derivative w.r.t. the curvilinear abscissa, vectorized over a list of parameters",
+            py::arg("u_lst"))
         .def(
             "__call__",
             &Curve<T, dim>::operator(),

--- a/python/gbsBindSurfaces.h
+++ b/python/gbsBindSurfaces.h
@@ -163,15 +163,43 @@ inline void gbs_bind_surfaces(py::module &m)
     .def("d_dmu", &Surface<T, dim>::d_dmu,
         "Unit tangent of the u-iso curve at (u, v)",
         py::arg("u"), py::arg("v"))
+    .def("d_dmu",
+            [](const Surface<T, dim>& self, const std::vector<std::array<T,2>>& uv_lst) {
+                py::array points = py::cast(self.d_dmus(uv_lst));
+                return points;
+        },
+        "Unit tangent of the u-iso curve, vectorized over a list of (u, v) parameters",
+        py::arg("uv_lst"))
     .def("d_dmv", &Surface<T, dim>::d_dmv,
         "Unit tangent of the v-iso curve at (u, v)",
         py::arg("u"), py::arg("v"))
+    .def("d_dmv",
+            [](const Surface<T, dim>& self, const std::vector<std::array<T,2>>& uv_lst) {
+                py::array points = py::cast(self.d_dmvs(uv_lst));
+                return points;
+        },
+        "Unit tangent of the v-iso curve, vectorized over a list of (u, v) parameters",
+        py::arg("uv_lst"))
     .def("d_dmu2", &Surface<T, dim>::d_dmu2,
         "Second derivative w.r.t. arc length along the u-iso curve",
         py::arg("u"), py::arg("v"))
+    .def("d_dmu2",
+            [](const Surface<T, dim>& self, const std::vector<std::array<T,2>>& uv_lst) {
+                py::array points = py::cast(self.d_dmu2s(uv_lst));
+                return points;
+        },
+        "Second derivative w.r.t. arc length along the u-iso curve, vectorized over a list of (u, v) parameters",
+        py::arg("uv_lst"))
     .def("d_dmv2", &Surface<T, dim>::d_dmv2,
         "Second derivative w.r.t. arc length along the v-iso curve",
         py::arg("u"), py::arg("v"))
+    .def("d_dmv2",
+            [](const Surface<T, dim>& self, const std::vector<std::array<T,2>>& uv_lst) {
+                py::array points = py::cast(self.d_dmv2s(uv_lst));
+                return points;
+        },
+        "Second derivative w.r.t. arc length along the v-iso curve, vectorized over a list of (u, v) parameters",
+        py::arg("uv_lst"))
     ;
 
     declare_bssurface<T,dim,false>(m);

--- a/tests/tests_bscurve.cpp
+++ b/tests/tests_bscurve.cpp
@@ -233,3 +233,37 @@ TEST(tests_bscurve, eval_except)
     auto crv =  gbs::build_segment<double,2>({0.,0.},{1.,0.});
     ASSERT_THROW(crv.value(2.), gbs::OutOfBoundsCurveEval<double>);
 }
+
+TEST(tests_bscurve, d_dm_vectorized)
+{
+    using T = double;
+    std::vector<T> k = {0., 0., 0., 1., 2., 3., 4., 5., 5., 5.};
+    std::vector<std::array<T,3>> poles =
+    {
+        {0.,0.,0.},
+        {0.,1.,0.},
+        {1.,1.,0.},
+        {1.,1.,1.},
+        {1.,1.,2.},
+        {3.,1.,1.},
+        {0.,4.,1.},
+    };
+    size_t p = 2;
+    gbs::BSCurve<T,3> crv{poles, k, p};
+
+    auto u_lst = gbs::make_range(k.front(), k.back(), 50);
+
+    // The vectorized derivatives w.r.t. the curvilinear abscissa must match the
+    // scalar overloads parameter by parameter.
+    auto d1 = crv.d_dms(u_lst);
+    auto d2 = crv.d_dm2s(u_lst);
+
+    ASSERT_EQ(d1.size(), u_lst.size());
+    ASSERT_EQ(d2.size(), u_lst.size());
+
+    for (size_t i{}; i < u_lst.size(); ++i)
+    {
+        ASSERT_LT(gbs::norm(d1[i] - crv.d_dm(u_lst[i])),  tol);
+        ASSERT_LT(gbs::norm(d2[i] - crv.d_dm2(u_lst[i])), tol);
+    }
+}

--- a/tests/tests_surface_derivatives.cpp
+++ b/tests/tests_surface_derivatives.cpp
@@ -104,3 +104,43 @@ TEST(tests_surface_derivatives, d_dmv2_matches_closed_form_along_v)
         EXPECT_NEAR(a[2],   2.0      / N2, tol) << "u=" << u << " v=" << v;
     }
 }
+
+TEST(tests_surface_derivatives, vectorized_arc_length_derivatives_match_scalar)
+{
+    const auto srf = make_paraboloid();
+    constexpr double tol = 1e-14;
+
+    std::vector<std::array<double, 2>> uv_lst;
+    for (double u : {0.0, 0.25, 0.5, 0.75, 1.0})
+    for (double v : {0.0, 0.25, 0.5, 0.75, 1.0})
+        uv_lst.push_back({u, v});
+
+    // The vectorized arc-length derivatives must match the scalar overloads
+    // entry by entry, in order.
+    const auto du   = srf.d_dmus(uv_lst);
+    const auto dv   = srf.d_dmvs(uv_lst);
+    const auto du2  = srf.d_dmu2s(uv_lst);
+    const auto dv2  = srf.d_dmv2s(uv_lst);
+
+    ASSERT_EQ(du.size(),  uv_lst.size());
+    ASSERT_EQ(dv.size(),  uv_lst.size());
+    ASSERT_EQ(du2.size(), uv_lst.size());
+    ASSERT_EQ(dv2.size(), uv_lst.size());
+
+    for (std::size_t i{}; i < uv_lst.size(); ++i)
+    {
+        const auto u = uv_lst[i][0];
+        const auto v = uv_lst[i][1];
+        const auto su   = srf.d_dmu(u, v);
+        const auto sv   = srf.d_dmv(u, v);
+        const auto su2  = srf.d_dmu2(u, v);
+        const auto sv2  = srf.d_dmv2(u, v);
+        for (std::size_t k{}; k < 3; ++k)
+        {
+            EXPECT_NEAR(du[i][k],  su[k],  tol) << "i=" << i << " k=" << k;
+            EXPECT_NEAR(dv[i][k],  sv[k],  tol) << "i=" << i << " k=" << k;
+            EXPECT_NEAR(du2[i][k], su2[k], tol) << "i=" << i << " k=" << k;
+            EXPECT_NEAR(dv2[i][k], sv2[k], tol) << "i=" << i << " k=" << k;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add vectorized derivatives w.r.t. the curvilinear abscissa (arc length), evaluated over a list of parameters, for both curves and surfaces, plus Python bindings.

### Curves (`gbs/bscurve.h`, `python/gbsBindCurves.h`)
- `Curve::d_dms` / `Curve::d_dm2s` — evaluate `d_dm` / `d_dm2` over a container of parameters via `std::transform`, returning a `points_vector<T, dim>`.
- Python: `d_dm` / `d_dm2` overloads accepting a list of parameters (NumPy array out).

### Surfaces (`gbs/bssurf.h`, `python/gbsBindSurfaces.h`)
- `Surface::d_dmus` / `d_dmvs` / `d_dmu2s` / `d_dmv2s` — the surface counterpart: unit iso-curve tangents and second arc-length derivatives over a list of `(u, v)` pairs.
- Python: `d_dmu` / `d_dmv` / `d_dmu2` / `d_dmv2` overloads accepting a list of `(u, v)` pairs.

### Changelog
- `News.md` — entry 13 jun 2026.

## Tests
- `tests_bscurve.d_dm_vectorized` — vectorized vs scalar `d_dm` / `d_dm2` on a degree-2 `BSCurve<double,3>`.
- `tests_surface_derivatives.vectorized_arc_length_derivatives_match_scalar` — vectorized vs scalar `d_dmu`/`d_dmv`/`d_dmu2`/`d_dmv2` on a paraboloid patch.
- Built (clang-21 / Ninja) and run locally → all PASSED.