### PR TITLE
perf(eval): one-pass multi-order curve/surface derivatives (follow-up to #30)

### DIFF
--- a/bench/REPORT.md
+++ b/bench/REPORT.md
@@ -160,6 +160,39 @@ multiplicity p (a C⁰ joint). The surface counterpart
 `tests_surface_derivatives.deriv_span_reduction_matches_full_span` does the same
 against a full-span recursive reference.
 
+## Update — one-pass derivatives (follow-up branch `perf/one-pass-derivatives`)
+
+The `d_dm2` follow-up flagged above is now done. A new one-pass multi-order API
+`derivatives(u, n, CK)` (curve) / `derivatives(u, v, nu, nv, SKL)` (surface) is
+added as a `virtual` on the `Curve`/`Surface` bases (default: loop `value()`),
+overridden on the B-spline classes with single-pass evaluators:
+`eval_ders_decasteljau` (curve & surface, one A2.3 basis pass shared across all
+orders) and `eval_rational_ders` (rational curve, Piegl & Tiller **A4.2**). The
+arc-length helpers `d_dm2`, `d_dmu2`, `d_dmv2` now take **one** basis pass
+instead of two `value()` calls.
+
+Curve degree sweep (N=2e5, 60 poles) — `d_dm2/d_dm` ratio collapses from ~2.0:
+
+| degree | d_dm2 before | d_dm2 now | ratio d_dm2/d_dm (before → now) |
+|--------|--------------|-----------|----------------------------------|
+| 2 | 73 ns  | 44 ns  | 1.64 → **1.04** |
+| 3 | 95 ns  | 59 ns  | 1.88 → **1.21** |
+| 5 | 147 ns | 89 ns  | 2.25 → **1.33** |
+| 7 | 211 ns | 126 ns | 2.33 → **1.54** |
+
+Surface `d_dmu2` (bidegree (3,3), 30×30): ~150 ns → **~110 ns** (≈1.35×). The
+residual >1.0 ratio is the unavoidable extra work of the higher derivative order
+itself (the A2.3 `a[]`-table recurrence), not a second pass.
+
+Rational **surface** derivatives remain unimplemented (their `value(du>0)` throws
+today); the surface override keeps that behaviour via the base default. Rational
+**curve** derivatives are now one-pass (A4.2).
+
+Correctness: `tests_curve_derivatives.derivatives_match_per_order_value_{nonrational,rational}`
+and `tests_surface_derivatives.derivatives_match_per_order_value` check the
+one-pass output against per-order `value()` to 1e-9, over a degree sweep and at
+multiplicity-p/q C⁰ joints. All 219 tests pass.
+
 ## Reproduce
 ```
 cmake -S bench -B bench/build -G Ninja -DCMAKE_BUILD_TYPE=Release \

--- a/gbs/basisfunctions.ixx
+++ b/gbs/basisfunctions.ixx
@@ -401,11 +401,186 @@
         return pt;
     }
 
+    /**
+     * @brief BSpline curve derivatives of all orders 0..n in a single pass.
+     *
+     * Computes C^(k)(u) for k in [0, n] and writes them into CK[0..n] (caller
+     * provides storage for n+1 points). A single allocation-free A2.3 pass yields
+     * every derivative order at once, so this replaces n+1 separate
+     * eval_value_decasteljau calls. Orders above the degree are exactly zero.
+     *
+     * @param CK output buffer of at least n+1 points
+     */
+    template <typename T, size_t dim>
+    void eval_ders_decasteljau(T u, const std::vector<T> &k, const points_vector<T, dim> &poles, size_t p, size_t n, std::array<T, dim> *CK)
+    {
+        for (size_t kk = 0; kk <= n; ++kk)
+            CK[kk].fill(T(0));
+
+        const size_t du = std::min(n, p); // orders above the degree stay zero
+        const size_t n_poles = poles.size();
+        size_t i = find_span(n_poles, p, u, k) - k.begin();
+        const size_t i_upper = (k.size() > p + 2) ? k.size() - p - 2 : 0;
+        i = std::min(i, i_upper);
+        const size_t i_min = (i >= p) ? i - p : 0;
+
+        if (p <= bspline_stack_max_degree)
+        {
+            T ders[(bspline_stack_max_degree + 1) * (bspline_stack_max_degree + 1)];
+            ders_basis_funs(i, p, du, u, k, ders);
+            for (size_t kk = 0; kk <= du; ++kk)
+                for (size_t r = 0; r <= p; ++r)
+                {
+                    const T N = ders[kk * (p + 1) + r];
+                    const auto &pole = poles[i_min + r];
+                    for (size_t c = 0; c < dim; ++c)
+                        CK[kk][c] += N * pole[c];
+                }
+        }
+        else
+        {
+            // Pathological degree: recursive fallback (correct, exponential).
+            for (size_t kk = 0; kk <= du; ++kk)
+                for (size_t ip = i_min; ip <= i; ++ip)
+                {
+                    const T N = basis_function(u, ip, p, kk, k);
+                    const auto &pole = poles[ip];
+                    for (size_t c = 0; c < dim; ++c)
+                        CK[kk][c] += N * pole[c];
+                }
+        }
+    }
+
+    // Forward declaration: defined later in this file, used by the n > max
+    // fallback of eval_rational_ders below. Default arguments live here (on the
+    // first declaration) so the later definition must not repeat them.
+    template <typename T, size_t dim>
+    auto eval_rational_value_simple(T u, const std::vector<T> &k, const std::vector<std::array<T, dim + 1>> &poles, size_t p, size_t d = 0, bool use_span_reduction = true) -> std::array<T, dim>;
+
+    /**
+     * @brief Rational BSpline curve derivatives of all orders 0..n in one pass.
+     *
+     * Piegl & Tiller A4.2 ("The NURBS Book"): evaluate the homogeneous curve
+     * derivatives Aders[0..n] (numerator) and the weight derivatives wders[0..n]
+     * once via eval_ders_decasteljau on the weighted poles, then apply the
+     * rational quotient rule. Writes the projected derivatives into CK[0..n].
+     *
+     * @param poles weighted poles (last coordinate is the weight)
+     * @param CK    output buffer of at least n+1 points
+     */
+    template <typename T, size_t dim>
+    void eval_rational_ders(T u, const std::vector<T> &k, const points_vector<T, dim + 1> &poles, size_t p, size_t n, std::array<T, dim> *CK)
+    {
+        if (n > bspline_stack_max_degree)
+        {
+            // Extremely high derivative order: fall back to the per-order path.
+            for (size_t kk = 0; kk <= n; ++kk)
+                CK[kk] = eval_rational_value_simple<T, dim>(u, k, poles, p, kk, false);
+            return;
+        }
+
+        std::array<std::array<T, dim + 1>, bspline_stack_max_degree + 1> Aders;
+        eval_ders_decasteljau<T, dim + 1>(u, k, poles, p, n, Aders.data());
+
+        const T w0 = Aders[0].back();
+        for (size_t kk = 0; kk <= n; ++kk)
+        {
+            std::array<T, dim> v;
+            for (size_t c = 0; c < dim; ++c)
+                v[c] = Aders[kk][c];
+            for (size_t i = 1; i <= kk; ++i)
+            {
+                const T b = binomial_law<T>(kk, i) * Aders[i].back();
+                for (size_t c = 0; c < dim; ++c)
+                    v[c] -= b * CK[kk - i][c];
+            }
+            for (size_t c = 0; c < dim; ++c)
+                CK[kk][c] = v[c] / w0;
+        }
+    }
+
+    /**
+     * @brief BSpline surface mixed derivatives, all orders up to (nu, nv), one pass.
+     *
+     * Computes S^(ku,kv)(u, v) for ku in [0, nu], kv in [0, nv] and writes them
+     * row-major into SKL: SKL[ku*(nv+1)+kv]. A single A2.3 pass per parametric
+     * direction yields every order, replacing (nu+1)*(nv+1) separate evaluations.
+     * Mixed orders above the respective degree are exactly zero.
+     *
+     * @param SKL output buffer of at least (nu+1)*(nv+1) points
+     */
+    template <typename T, size_t dim>
+    void eval_ders_decasteljau(T u, T v, const std::vector<T> &ku, const std::vector<T> &kv, const std::vector<std::array<T, dim>> &poles, size_t p, size_t q, size_t nu, size_t nv, std::array<T, dim> *SKL)
+    {
+        for (size_t a = 0; a <= nu; ++a)
+            for (size_t b = 0; b <= nv; ++b)
+                SKL[a * (nv + 1) + b].fill(T(0));
+
+        const size_t du = std::min(nu, p);
+        const size_t dv = std::min(nv, q);
+        const size_t n_polesU = ku.size() - p - 1;
+        const size_t n_polesV = kv.size() - q - 1;
+
+        size_t i = find_span(n_polesU, p, u, ku) - ku.begin();
+        size_t j = find_span(n_polesV, q, v, kv) - kv.begin();
+        const size_t i_upper = (ku.size() > p + 2) ? ku.size() - p - 2 : 0;
+        const size_t j_upper = (kv.size() > q + 2) ? kv.size() - q - 2 : 0;
+        i = std::min(i, i_upper);
+        j = std::min(j, j_upper);
+        const size_t i_min = (i >= p) ? i - p : 0;
+        const size_t j_min = (j >= q) ? j - q : 0;
+
+        if (p <= bspline_stack_max_degree && q <= bspline_stack_max_degree)
+        {
+            T dersU[(bspline_stack_max_degree + 1) * (bspline_stack_max_degree + 1)];
+            T dersV[(bspline_stack_max_degree + 1) * (bspline_stack_max_degree + 1)];
+            ders_basis_funs(i, p, du, u, ku, dersU);
+            ders_basis_funs(j, q, dv, v, kv, dersV);
+            for (size_t ku_ = 0; ku_ <= du; ++ku_)
+                for (size_t kv_ = 0; kv_ <= dv; ++kv_)
+                {
+                    auto &dst = SKL[ku_ * (nv + 1) + kv_];
+                    for (size_t rj = 0; rj <= q; ++rj)
+                    {
+                        const T nvw = dersV[kv_ * (q + 1) + rj];
+                        const size_t row = n_polesU * (j_min + rj);
+                        for (size_t ri = 0; ri <= p; ++ri)
+                        {
+                            const T w = dersU[ku_ * (p + 1) + ri] * nvw;
+                            const auto &pole = poles[i_min + ri + row];
+                            for (size_t c = 0; c < dim; ++c)
+                                dst[c] += w * pole[c];
+                        }
+                    }
+                }
+        }
+        else
+        {
+            // Pathological degree: recursive fallback (correct, exponential).
+            for (size_t ku_ = 0; ku_ <= du; ++ku_)
+                for (size_t kv_ = 0; kv_ <= dv; ++kv_)
+                {
+                    auto &dst = SKL[ku_ * (nv + 1) + kv_];
+                    for (size_t jj = j_min; jj <= j; ++jj)
+                    {
+                        const T Nvv = basis_function(v, jj, q, kv_, kv);
+                        for (size_t ii = i_min; ii <= i; ++ii)
+                        {
+                            const T Nuu = basis_function(u, ii, p, ku_, ku);
+                            const auto &pole = poles[ii + n_polesU * jj];
+                            for (size_t c = 0; c < dim; ++c)
+                                dst[c] += Nuu * Nvv * pole[c];
+                        }
+                    }
+                }
+        }
+    }
+
 
     // TODO Seems dead code
     /**
      * @brief BSpline curve evaluation using simple recursive basis functions
-     * 
+     *
      * @tparam T 
      * @tparam dim 
      * @param u parameter on curve
@@ -859,7 +1034,7 @@
      * @return std::array<T, dim> 
      */
     template <typename T, size_t dim>
-    auto eval_rational_value_simple(T u, const std::vector<T> &k, const std::vector<std::array<T, dim+1>> &poles, size_t p, size_t d = 0,bool use_span_reduction =true) -> std::array<T, dim>
+    auto eval_rational_value_simple(T u, const std::vector<T> &k, const std::vector<std::array<T, dim+1>> &poles, size_t p, size_t d,bool use_span_reduction) -> std::array<T, dim>
     {
         if (d == 0)
         {

--- a/gbs/bscurve.h
+++ b/gbs/bscurve.h
@@ -108,10 +108,23 @@ namespace gbs
             return this->value(bounds()[1], d);
         }
         /**
+         * @brief Curve derivatives of all orders 0..n at u, in a single call.
+         *
+         * Fills CK[0..n] with C^(k)(u); the caller provides storage for n+1
+         * points. The default implementation evaluates each order through
+         * value(); B-spline curves override it with a one-pass evaluator that
+         * shares a single basis-function pass across all orders (see
+         * BSCurveGeneral::derivatives).
+         */
+        virtual auto derivatives(T u, size_t n, std::array<T, dim>* CK) const -> void
+        {
+            for (size_t k = 0; k <= n; ++k) CK[k] = value(u, k);
+        }
+        /**
          * @brief Curve first derivative respectively to the curvilinear abscissa
-         * 
-         * @param u 
-         * @return std::array<T, dim> 
+         *
+         * @param u
+         * @return std::array<T, dim>
          */
         auto d_dm(T u) const -> std::array<T, dim>
         {
@@ -120,14 +133,16 @@ namespace gbs
         }
         /**
          * @brief Curve second derivative respectively to the curvilinear abscissa
-         * 
-         * @param u 
-         * @return std::array<T, dim> 
+         *
+         * @param u
+         * @return std::array<T, dim>
          */
         auto d_dm2(T u) const -> std::array<T, dim>
         {
-            auto d_du  = value(u,1);
-            auto d_du2 = value(u,2);
+            std::array<std::array<T, dim>, 3> CK;
+            derivatives(u, 2, CK.data());  // C, C', C'' in one pass on B-splines
+            const auto &d_du  = CK[1];
+            const auto &d_du2 = CK[2];
             auto N     = sq_norm(d_du);     // |C'|^2
             auto cp_cs = d_du * d_du2;      // C' . C''
             return (d_du2 * N - d_du * cp_cs) / (N * N);
@@ -570,6 +585,15 @@ namespace gbs
             return eval_value_decasteljau(u, this->knotsFlats(), this->poles(), this->degree(), d);
         }
 
+        virtual auto derivatives(T u, size_t n, std::array<T, dim>* CK) const -> void override
+        {
+            if (u < this->bounds()[0] - knot_eps<T>|| u > this->bounds()[1] + knot_eps<T>)
+            {
+                throw OutOfBoundsCurveEval(u,this->bounds());
+            }
+            eval_ders_decasteljau(u, this->knotsFlats(), this->poles(), this->degree(), n, CK);
+        }
+
     };
 
     template <typename T, size_t dim>
@@ -608,6 +632,14 @@ namespace gbs
                 throw OutOfBoundsCurveEval(u,this->bounds());
             }
             return eval_rational_value_simple<T,dim>(u,this->knotsFlats(),this->poles(),this->degree(),d);
+        }
+        virtual auto derivatives(T u, size_t n, std::array<T, dim>* CK) const -> void override
+        {
+            if (u < this->bounds()[0] - knot_eps<T>|| u > this->bounds()[1] + knot_eps<T>)
+            {
+                throw OutOfBoundsCurveEval(u,this->bounds());
+            }
+            eval_rational_ders<T,dim>(u,this->knotsFlats(),this->poles(),this->degree(),n,CK);
         }
         auto polesProjected() const -> points_vector<T,dim>
         {

--- a/gbs/bssurf.h
+++ b/gbs/bssurf.h
@@ -236,6 +236,22 @@ namespace gbs
         }
 
         /**
+         * @brief Surface mixed derivatives of all orders up to (nu, nv) at (u, v).
+         *
+         * Fills SKL[ku*(nv+1)+kv] (row-major) with S^(ku,kv)(u, v) for
+         * ku in [0, nu], kv in [0, nv]; the caller provides storage for
+         * (nu+1)*(nv+1) points. The default implementation evaluates each order
+         * through value(); B-spline surfaces override it with a one-pass
+         * evaluator (see BSSurfaceGeneral::derivatives).
+         */
+        virtual auto derivatives(T u, T v, size_t nu, size_t nv, std::array<T, dim>* SKL) const -> void
+        {
+            for (size_t a = 0; a <= nu; ++a)
+                for (size_t b = 0; b <= nv; ++b)
+                    SKL[a * (nv + 1) + b] = value(u, v, a, b);
+        }
+
+        /**
          * @brief Unit tangent of the u-iso curve at (u, v):
          *        derivative of S w.r.t. the arc length along the curve
          *        u -> S(u, v) at fixed v.
@@ -264,8 +280,10 @@ namespace gbs
          */
         auto d_dmu2(T u, T v) const -> point<T, dim>
         {
-            auto S_u  = value(u, v, 1, 0);
-            auto S_uu = value(u, v, 2, 0);
+            std::array<point<T, dim>, 3> SKL;     // nv=0 => (0,0),(1,0),(2,0)
+            derivatives(u, v, 2, 0, SKL.data());  // one pass on B-spline surfaces
+            const auto &S_u  = SKL[1];
+            const auto &S_uu = SKL[2];
             auto N    = sq_norm(S_u);       // |S_u|^2
             auto dot_ = S_u * S_uu;         // S_u . S_uu
             return (S_uu * N - S_u * dot_) / (N * N);
@@ -277,8 +295,10 @@ namespace gbs
          */
         auto d_dmv2(T u, T v) const -> point<T, dim>
         {
-            auto S_v  = value(u, v, 0, 1);
-            auto S_vv = value(u, v, 0, 2);
+            std::array<point<T, dim>, 3> SKL;     // nu=0 => (0,0),(0,1),(0,2)
+            derivatives(u, v, 0, 2, SKL.data());  // one pass on B-spline surfaces
+            const auto &S_v  = SKL[1];
+            const auto &S_vv = SKL[2];
             auto N    = sq_norm(S_v);       // |S_v|^2
             auto dot_ = S_v * S_vv;         // S_v . S_vv
             return (S_vv * N - S_v * dot_) / (N * N);
@@ -793,6 +813,24 @@ namespace gbs
         virtual auto bounds() const -> std::array<T, 4> override
         {
             return m_bounds;
+        }
+
+        virtual auto derivatives(T u, T v, size_t nu, size_t nv, std::array<T, dim>* SKL) const -> void override
+        {
+            if constexpr (rational)
+            {
+                // Rational surface derivatives are not implemented (value() throws
+                // for du>0 / dv>0); keep that behaviour via the base default.
+                Surface<T, dim>::derivatives(u, v, nu, nv, SKL);
+            }
+            else
+            {
+                if (u < m_bounds[0] - knot_eps<T> || u > m_bounds[1] + knot_eps<T>)
+                    throw OutOfBoundsSurfaceUEval<T>(u, this->boundsU());
+                if (v < m_bounds[2] - knot_eps<T> || v > m_bounds[3] + knot_eps<T>)
+                    throw OutOfBoundsSurfaceVEval<T>(v, this->boundsV());
+                eval_ders_decasteljau(u, v, m_knotsFlatsU, m_knotsFlatsV, m_poles, m_degU, m_degV, nu, nv, SKL);
+            }
         }
 
         /**

--- a/tests/tests_curve_derivatives.cpp
+++ b/tests/tests_curve_derivatives.cpp
@@ -61,3 +61,90 @@ TEST(tests_curve_derivatives, d_dm2_matches_closed_form_on_parabola)
         EXPECT_NEAR(a[1], ay, tol) << "u=" << u;
     }
 }
+
+namespace
+{
+    template <size_t dim>
+    double diff_norm(const std::array<double, dim> &a, const std::array<double, dim> &b)
+    {
+        double s = 0.;
+        for (size_t c = 0; c < dim; ++c) { double e = a[c] - b[c]; s += e * e; }
+        return std::sqrt(s);
+    }
+
+    // Clamped knot vector of degree p with one interior knot of multiplicity p
+    // (a C^0 joint, where one-sided derivatives are discontinuous).
+    std::vector<double> c0_knots(size_t p)
+    {
+        std::vector<double> k;
+        for (size_t i = 0; i <= p; ++i) k.push_back(0.);
+        k.push_back(1.);
+        for (size_t i = 0; i < p; ++i) k.push_back(2.); // interior mult == p
+        k.push_back(3.);
+        for (size_t i = 0; i <= p; ++i) k.push_back(4.);
+        return k;
+    }
+}
+
+// The one-pass multi-order derivatives(u, n, CK) must agree with calling
+// value(u, k) per order, for every order including beyond the degree, sampled
+// on a grid plus every distinct knot (incl. a multiplicity-p C^0 joint).
+TEST(tests_curve_derivatives, derivatives_match_per_order_value_nonrational)
+{
+    using T = double;
+    constexpr size_t nmax = 4;
+    for (size_t p : {size_t{2}, size_t{3}, size_t{5}})
+    {
+        const auto k = c0_knots(p);
+        const size_t n_poles = k.size() - p - 1;
+        std::vector<std::array<T, 3>> poles(n_poles);
+        for (size_t i = 0; i < n_poles; ++i)
+            poles[i] = {T(i), T((i * 5) % 7), T((i * 2) % 3)};
+        gbs::BSCurve<T, 3> crv(poles, k, p);
+
+        auto us = gbs::make_range(k.front(), k.back(), 40);
+        for (auto kv : k) us.push_back(kv);
+
+        std::array<std::array<T, 3>, nmax + 1> CK;
+        for (auto u : us)
+        {
+            crv.derivatives(u, nmax, CK.data());
+            for (size_t d = 0; d <= nmax; ++d)
+                ASSERT_LT(diff_norm<3>(CK[d], crv.value(u, d)), 1e-9)
+                    << "p=" << p << " d=" << d << " u=" << u;
+        }
+    }
+}
+
+// Same for the rational path: the one-pass A4.2 derivatives must match the
+// per-order rational value() (eval_rational_value_simple).
+TEST(tests_curve_derivatives, derivatives_match_per_order_value_rational)
+{
+    using T = double;
+    constexpr size_t nmax = 3;
+    for (size_t p : {size_t{2}, size_t{3}})
+    {
+        const auto k = c0_knots(p);
+        const size_t n_poles = k.size() - p - 1;
+        std::vector<std::array<T, 3>> poles(n_poles);
+        std::vector<T> weights(n_poles);
+        for (size_t i = 0; i < n_poles; ++i)
+        {
+            poles[i] = {T(i), T((i * 5) % 7), T((i * 2) % 3)};
+            weights[i] = T(1) + T((i * 3) % 5) * T(0.5); // non-trivial weights
+        }
+        gbs::BSCurveRational<T, 3> crv(poles, k, weights, p);
+
+        auto us = gbs::make_range(k.front(), k.back(), 40);
+        for (auto kv : k) us.push_back(kv);
+
+        std::array<std::array<T, 3>, nmax + 1> CK;
+        for (auto u : us)
+        {
+            crv.derivatives(u, nmax, CK.data());
+            for (size_t d = 0; d <= nmax; ++d)
+                ASSERT_LT(diff_norm<3>(CK[d], crv.value(u, d)), 1e-9)
+                    << "p=" << p << " d=" << d << " u=" << u;
+        }
+    }
+}

--- a/tests/tests_surface_derivatives.cpp
+++ b/tests/tests_surface_derivatives.cpp
@@ -205,3 +205,49 @@ TEST(tests_surface_derivatives, deriv_span_reduction_matches_full_span)
                 << "du=" << du << " dv=" << dv << " u=" << u << " v=" << v;
         }
 }
+
+// The one-pass multi-order derivatives(u, v, nu, nv, SKL) must agree with
+// calling value(u, v, ku, kv) per mixed order, sampled on a grid plus every
+// distinct knot, with interior knots of multiplicity p/q (C^0 joints).
+TEST(tests_surface_derivatives, derivatives_match_per_order_value)
+{
+    using T = double;
+    constexpr double tol = 1e-9;
+
+    // Bidegree (2,2) with interior knots u=2 (mult 2) and v=2 (mult 2).
+    const std::vector<T> ku{0.,0.,0., 1., 2.,2., 3., 4.,4.,4.};
+    const std::vector<T> kv{0.,0.,0., 1., 2.,2., 3., 4.,4.,4.};
+    const size_t p = 2, q = 2;
+    const size_t nu = ku.size() - p - 1;
+    const size_t nv = kv.size() - q - 1;
+
+    gbs::points_vector<T, 3> poles(nu * nv);
+    for (size_t j = 0; j < nv; ++j)
+        for (size_t i = 0; i < nu; ++i)
+            poles[j * nu + i] = {T(i), T(j), 0.3 * T(i) + 0.7 * T(j) * T(j) - 0.2 * T(i) * T(j)};
+
+    gbs::BSSurface<T, 3> srf(poles, ku, kv, p, q);
+
+    std::vector<T> us, vs;
+    for (size_t i = 0; i <= 6; ++i) { us.push_back(4.0 * T(i) / 6.0); vs.push_back(4.0 * T(i) / 6.0); }
+    for (T x : ku) us.push_back(x);
+    for (T x : kv) vs.push_back(x);
+
+    const size_t Nu = 3, Nv = 3; // request orders 0..3 in each direction
+    std::array<std::array<T, 3>, (Nu + 1) * (Nv + 1)> SKL;
+    for (T u : us)
+        for (T v : vs)
+        {
+            srf.derivatives(u, v, Nu, Nv, SKL.data());
+            for (size_t ku_ = 0; ku_ <= Nu; ++ku_)
+                for (size_t kv_ = 0; kv_ <= Nv; ++kv_)
+                {
+                    const auto ref = srf.value(u, v, ku_, kv_);
+                    const auto &got = SKL[ku_ * (Nv + 1) + kv_];
+                    T err2 = 0;
+                    for (size_t c = 0; c < 3; ++c) { T e = got[c] - ref[c]; err2 += e * e; }
+                    ASSERT_LT(std::sqrt(err2), tol)
+                        << "ku=" << ku_ << " kv=" << kv_ << " u=" << u << " v=" << v;
+                }
+        }
+}


### PR DESCRIPTION
Follow-up to #30 (now merged): make `d_dm2` (and the surface `d_dmu2`/`d_dmv2`) take **one** basis-function pass instead of two `value()` calls. Rebased onto `master`.

## What

A one-pass multi-order derivative API:

- **`derivatives(u, n, CK)`** on `Curve` and **`derivatives(u, v, nu, nv, SKL)`** on `Surface`, added as `virtual` with a default that just loops `value()` — so every non-B-spline curve/surface type keeps its exact current behaviour.
- B-spline classes override it with single-pass evaluators (new in `basisfunctions.ixx`):
  - `eval_ders_decasteljau` (curve **and** surface) — one shared A2.3 basis pass yields all derivative orders; the surface computes the `du`/`dv` basis rows once each then forms the outer product.
  - `eval_rational_ders` (rational curve) — Piegl & Tiller **A4.2**: homogeneous derivatives once, then the rational quotient rule.
  - Both allocation-free, reusing `ders_basis_funs` from #30, with the same recursive fallback above `bspline_stack_max_degree`.
- `d_dm2` / `d_dmu2` / `d_dmv2` rewritten to fetch the orders they need in one call. `d_dm` / `d_dmu` / `d_dmv` are unchanged (already single-order, single-pass).
- Rational **surface** derivatives stay unimplemented (their `value(du>0)` throws today); the surface override preserves that via the base default.

## Results (clang-21 `-O3`, 60 poles, N=2e5)

The `d_dm2/d_dm` ratio collapses from ~2.0:

| degree | d_dm2 before | d_dm2 now | ratio (before → now) |
|--------|--------------|-----------|----------------------|
| 2 | 73 ns  | 44 ns  | 1.64 → **1.04** |
| 3 | 95 ns  | 59 ns  | 1.88 → **1.21** |
| 5 | 147 ns | 89 ns  | 2.25 → **1.33** |
| 7 | 211 ns | 126 ns | 2.33 → **1.54** |

Surface `d_dmu2` (bidegree (3,3), 30×30): ~150 ns → **~110 ns**. The residual >1.0 ratio is the extra work of the higher derivative order itself (A2.3 `a[]`-table), not a second pass.

## Correctness

- New `tests_curve_derivatives.derivatives_match_per_order_value_{nonrational,rational}` and `tests_surface_derivatives.derivatives_match_per_order_value` check the one-pass output against per-order `value()` to 1e-9, over a degree sweep and at multiplicity-p/q C⁰ joints (incl. the rational A4.2 path).
- The closed-form `d_dm2`/`d_dmu2`/`d_dmv2` tests still pass (they now exercise the one-pass path).
- **All 219 tests pass.**
