### PR TITLE
perf(interp): separable solve for tensor-product surface interpolation (#34)

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -23,3 +23,7 @@ target_link_libraries(bench_arc_length_derivatives PRIVATE Eigen3::Eigen)
 add_executable(bench_eval_compare bench_eval_compare.cpp)
 target_include_directories(bench_eval_compare PRIVATE ${GBS_ROOT} ${GBS_ROOT}/inc)
 target_link_libraries(bench_eval_compare PRIVATE Eigen3::Eigen)
+
+add_executable(bench_interp bench_interp.cpp)
+target_include_directories(bench_interp PRIVATE ${GBS_ROOT} ${GBS_ROOT}/inc)
+target_link_libraries(bench_interp PRIVATE Eigen3::Eigen)

--- a/bench/INTERP_AUDIT.md
+++ b/bench/INTERP_AUDIT.md
@@ -1,0 +1,111 @@
+# Performance audit — B-spline interpolation
+
+Scope: the interpolation builders in `gbs/bscinterp.h`, `gbs/bssinterp.h` and the
+shared `build_poles_matrix` in `gbs/knotsfunctions.ixx`. These turn a set of
+constraints (points / derivatives) into control poles by assembling a collocation
+matrix `N` and solving `N · poles = Q`.
+
+Harness: `bench/bench_interp.cpp`, header-only, clang-21 `-O3 -march=haswell`,
+`double`, `dim=3`. Best-of-N total `interpolate()` wall time.
+
+## TL;DR
+
+Interpolation has **three compounding inefficiencies**, all in matrix assembly +
+solve. None are on the curve *evaluation* path fixed in #30/#32 — this is a
+separate, larger win:
+
+1. **Dense factorization of a structured matrix.** The collocation matrix is
+   *banded* (curve) / *separable Kronecker* (tensor-product surface), but it is
+   stored dense and factorized with `partialPivLu` — `O(n³)` for curves,
+   `O((nu·nv)³)` for surfaces. The surface code even says `//TODO solve banded
+   system`.
+2. **All n² entries assembled, though only `p+1` per row are non-zero.** The
+   assembly loops every (row, col) pair instead of the band around the span.
+3. **Each entry via the recursive `basis_function`** (`~O(p·2^p)`, the same
+   exponential kernel replaced in #30) instead of one `ders_basis_funs` pass per
+   row.
+
+## Measured
+
+### Curve, degree 3, vs #points
+| n_points | time ms | × per doubling |
+|----------|---------|----------------|
+| 50       | 0.41    | –     |
+| 100      | 0.91    | 2.2×  |
+| 200      | 4.13    | 4.5×  |
+| 400      | 23.2    | 5.6×  |
+| 800      | 269.9   | 11.6× |
+
+Super-cubic growth (a doubling costs 5–12×): the dense `O(n³)` LU dominates at
+scale, on top of `O(n²)` assembly. 800 points already costs **0.27 s**.
+
+### Curve, n=200, vs degree
+| degree | 1 | 2 | 3 | 5 | 7 | 9 |
+|--------|---|---|---|---|---|---|
+| time ms| 3.17 | 3.49 | 4.15 | 7.67 | 22.7 | 83.7 |
+
+With `n` fixed the solve is ~constant, so this curve is **pure assembly cost** —
+and it explodes `~2^p` (p3→p9 is 20×). This is inefficiency #3 in isolation.
+
+### Surface, bidegree (3,3), vs grid side N (N×N)
+| N  | poles | time ms | × prev |
+|----|-------|---------|--------|
+| 8  | 64    | 0.35    | –      |
+| 12 | 144   | 1.90    | 5.4×   |
+| 16 | 256   | 7.38    | 3.9×   |
+| 24 | 576   | 95.8    | 13.0×  |
+| 32 | 1024  | 606.1   | 6.3×   |
+
+N=16→32 (poles ×4) is **82×** in time ≈ `N^6.4` — i.e. the dense
+`O((nu·nv)³)` solve. A 32×32 grid already costs **0.6 s**; a 64×64 grid would be
+~30–40 s. This is the single worst hotspot in the library's batch paths.
+
+## Root causes (by file)
+
+- `knotsfunctions.ixx:848 build_poles_matrix` and `bscinterp.h:139`,
+  `bscinterp.h:332-351`: nested `i,j` over the full `n×n`, `N(i,j) =
+  basis_function(...)` (recursive). #2 + #3.
+- `bscinterp.h:104,146,353`: `N.partialPivLu()` on a dense `n×n`. #1.
+- `bssinterp.h:51 fill_poles_matrix`: full `(nu·nv)×(nu·nv)` assembly as the
+  Kronecker product `Nv ⊗ Nu`, then `bssinterp.h:116 build_poles(N.partialPivLu(),
+  Q)` — one dense `O((nu·nv)³)` solve. #1 + #2 + #3, and ignores separability.
+- `bssinterp.h:191`: scattered-constraint surface builder, same dense full
+  assembly.
+
+Note: factorization **is** correctly reused across the `dim` spatial components
+(one factorization, `dim` cheap back-substitutions) — that part is already good.
+The waste is purely structural: dense, full, recursive.
+
+## Recommended fixes (priority order)
+
+1. **Surface: exploit separability (biggest win).** For grid interpolation the
+   system is `(Nv ⊗ Nu) · P = Q`. Solve it as two sets of 1-D banded systems:
+   factor `Nu` (size nu) and `Nv` (size nv) once, solve `Nu` across the nv rows,
+   then `Nv` across the nu columns. Cost drops from `O((nu·nv)³)` to roughly
+   `O(nu·nv·(p²+q²))` — from `~N^6` to `~N²`. Expect 32×32: 606 ms → low single
+   ms (>100×), and large grids become feasible.
+2. **Band assembly + one-pass basis (curve & surface).** Use `find_span` to fill
+   only the `p+1` non-zero entries per row, each row from a single
+   `ders_basis_funs` pass (the alloc-free A2.3 from #30, now in `master`) instead
+   of `p+1` recursive `basis_function` calls. Removes #2 and #3 together; flattens
+   the degree explosion (p9 curve 84 ms → a few ms).
+3. **Banded solve for curves.** Store `N` banded (Eigen `BandMatrix` / a sparse
+   `SparseLU`, or a hand-rolled LU for the totally-positive band) → `O(n·p²)`
+   factorization instead of `O(n³)`. 800 pts/p3: 270 ms → low single ms.
+
+Caveats:
+- The band/separable structure holds for the **sequence / grid** interpolators
+  (simple knots, monotone params). The **scattered-constraint** builders
+  (`constrPoint`, `bsc_constraint`, `bss_constraint`) need the constraints sorted
+  first to be banded — there is already a `//TODO sort Q ... to get a block
+  system`. Banding those is a follow-up; the one-pass basis (#2/#3) applies to
+  them regardless.
+- Derivative-constrained interpolation (`nc>1`) yields a *block*-banded matrix —
+  still bandable, just with a wider band.
+
+## Reproduce
+```
+cmake -S bench -B bench/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -march=haswell"
+cmake --build bench/build --target bench_interp
+./bench/build/bench_interp
+```

--- a/bench/INTERP_AUDIT.md
+++ b/bench/INTERP_AUDIT.md
@@ -76,11 +76,30 @@ Note: factorization **is** correctly reused across the `dim` spatial components
 (one factorization, `dim` cheap back-substitutions) — that part is already good.
 The waste is purely structural: dense, full, recursive.
 
+## Status
+
+- **Plan #1 (surface separable solve) — DONE** (this branch). `bssinterp.h`
+  `build_poles` (grid path) now factors the two 1-D collocation matrices `Mu`,
+  `Mv` and solves `P = Mu⁻¹ · Q · Mv⁻ᵀ` instead of forming/solving the dense
+  Kronecker matrix. Measured (bidegree (3,3)):
+
+  | N  | before | after | speedup |
+  |----|--------|-------|---------|
+  | 8  | 0.35 ms| 0.034 ms | 10×   |
+  | 16 | 7.38 ms| 0.113 ms | 65×   |
+  | 24 | 95.8 ms| 0.208 ms | 460×  |
+  | 32 | 606 ms | 0.413 ms | **1467×** |
+
+  Scaling went from ~N⁶ to ~N² (a 64×64 grid: ~30-40 s → ~1.6 ms). Poles match
+  the old dense solve to ~1e-9 (`tests_bssurf.grid_interp_separable_matches_dense`).
+  Curve numbers are unchanged (untouched path).
+- Plan #2 / #3 (band assembly + one-pass basis, banded curve solve) — TODO.
+
 ## Recommended fixes (priority order)
 
-1. **Surface: exploit separability (biggest win).** For grid interpolation the
-   system is `(Nv ⊗ Nu) · P = Q`. Solve it as two sets of 1-D banded systems:
-   factor `Nu` (size nu) and `Nv` (size nv) once, solve `Nu` across the nv rows,
+1. **Surface: exploit separability (biggest win).** ✅ DONE — see Status. For grid
+   interpolation the system is `(Nv ⊗ Nu) · P = Q`. Solve it as two sets of 1-D
+   solves: factor `Nu` (size nu) and `Nv` (size nv) once, solve `Nu` across rows,
    then `Nv` across the nu columns. Cost drops from `O((nu·nv)³)` to roughly
    `O(nu·nv·(p²+q²))` — from `~N^6` to `~N²`. Expect 32×32: 606 ms → low single
    ms (>100×), and large grids become feasible.

--- a/bench/bench_interp.cpp
+++ b/bench/bench_interp.cpp
@@ -1,0 +1,117 @@
+// Performance audit harness for B-spline interpolation.
+//
+// Curve : gbs::interpolate(points, p, CHORD_LENGTH)  -> build_poles
+//           -> build_poles_matrix (dense, recursive basis_function, all n^2
+//              entries) + dense partialPivLu (O(n^3)).
+// Surface: gbs::interpolate(grid, n_v, p, q, CHORD_LENGTH) -> build_poles
+//           -> fill_poles_matrix (dense Kronecker, (nu*nv)^2 entries) +
+//              dense partialPivLu (O((nu*nv)^3)).
+//
+// We measure total interpolate() wall time and read off the scaling exponent
+// (curve vs #points and vs degree; surface vs grid side N).
+
+#include <gbs/bscinterp.h>
+#include <gbs/bssinterp.h>
+
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using clk = std::chrono::steady_clock;
+volatile double sink = 0.0;
+
+template <typename F>
+double best_ms(int reps, F &&f)
+{
+    double best = 1e300;
+    for (int r = 0; r < reps; ++r)
+    {
+        auto t0 = clk::now();
+        f();
+        auto t1 = clk::now();
+        best = std::min(best, std::chrono::duration<double, std::milli>(t1 - t0).count());
+    }
+    return best;
+}
+
+static gbs::points_vector<double, 3> sample_curve(size_t n)
+{
+    gbs::points_vector<double, 3> Q(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        double t = double(i) / double(n - 1);
+        Q[i] = {std::cos(6.0 * t), std::sin(6.0 * t), 2.0 * t};
+    }
+    return Q;
+}
+
+static std::vector<std::array<double, 3>> sample_grid(size_t nu, size_t nv)
+{
+    std::vector<std::array<double, 3>> Q(nu * nv); // U-first, V-outer
+    for (size_t j = 0; j < nv; ++j)
+        for (size_t i = 0; i < nu; ++i)
+        {
+            double u = double(i) / double(nu - 1);
+            double v = double(j) / double(nv - 1);
+            Q[j * nu + i] = {u, v, std::sin(3.0 * u) * std::cos(3.0 * v)};
+        }
+    return Q;
+}
+
+int main()
+{
+    using namespace gbs;
+    const auto mode = KnotsCalcMode::CHORD_LENGTH;
+
+    std::printf("CURVE interpolation, degree=3, vs #points (total interpolate() ms)\n");
+    std::printf("%-10s %12s %12s\n", "n_points", "time ms", "x prev");
+    std::printf("-----------------------------------------\n");
+    double prev = 0;
+    for (size_t n : {50u, 100u, 200u, 400u, 800u})
+    {
+        auto Q = sample_curve(n);
+        int reps = n <= 200 ? 7 : 3;
+        double ms = best_ms(reps, [&] {
+            auto c = interpolate<double, 3>(Q, size_t{3}, mode);
+            sink += c.poles()[0][0];
+        });
+        std::printf("%-10zu %12.3f %12s\n", n, ms,
+                    prev > 0 ? (std::to_string(ms / prev) + "x").c_str() : "-");
+        prev = ms;
+    }
+
+    std::printf("\nCURVE interpolation, n_points=200, vs degree (total ms)\n");
+    std::printf("%-10s %12s\n", "degree", "time ms");
+    std::printf("--------------------------\n");
+    for (size_t p : {1u, 2u, 3u, 5u, 7u, 9u})
+    {
+        auto Q = sample_curve(200);
+        double ms = best_ms(5, [&] {
+            auto c = interpolate<double, 3>(Q, p, mode);
+            sink += c.poles()[0][0];
+        });
+        std::printf("%-10zu %12.3f\n", p, ms);
+    }
+
+    std::printf("\nSURFACE interpolation, bidegree=(3,3), vs grid side N (NxN) (total ms)\n");
+    std::printf("%-10s %12s %12s %12s\n", "N", "poles", "time ms", "x prev");
+    std::printf("-------------------------------------------------------\n");
+    prev = 0;
+    for (size_t N : {8u, 12u, 16u, 24u, 32u})
+    {
+        auto Q = sample_grid(N, N);
+        int reps = N <= 16 ? 5 : 2;
+        double ms = best_ms(reps, [&] {
+            auto s = interpolate<double, 3>(Q, size_t{N}, size_t{3}, size_t{3}, mode);
+            sink += s.poles()[0][0];
+        });
+        std::printf("%-10zu %12zu %12.3f %12s\n", N, N * N, ms,
+                    prev > 0 ? (std::to_string(ms / prev) + "x").c_str() : "-");
+        prev = ms;
+    }
+
+    std::printf("[sink=%g]\n", sink);
+    return 0;
+}

--- a/gbs/bssinterp.h
+++ b/gbs/bssinterp.h
@@ -110,11 +110,44 @@ namespace gbs
         {
             throw std::length_error("size error");
         }
-        MatrixX<T> N(n_poles, n_poles);
-        fill_poles_matrix(N,k_flat_u,k_flat_v,u,v,p,q);
 
-        return build_poles(N.partialPivLu(),Q);//TODO solve banded system
+        // Tensor-product (grid) interpolation: the (nu*nv)x(nu*nv) collocation
+        // matrix is the Kronecker product Mv (x) Mu, so the system separates as
+        //   Mu * P * Mv^T = Q   =>   P = Mu^-1 * Q * Mv^-T,
+        // with Mu (nu x nu) and Mv (nv x nv) the 1-D collocation matrices. We
+        // factor the two small matrices once and solve as two sequences of 1-D
+        // solves instead of one dense O((nu*nv)^3) LU (issue #34). Poles and Q
+        // are stored U-first: index i + n_poles_u * j.
+        MatrixX<T> Mu(n_poles_u, n_poles_u);
+        for (size_t iu = 0; iu < n_params_u; ++iu)
+            for (size_t i = 0; i < n_poles_u; ++i)
+                Mu(iu, i) = basis_function(u[iu], i, p, size_t{0}, k_flat_u);
 
+        MatrixX<T> Mv(n_poles_v, n_poles_v);
+        for (size_t iv = 0; iv < n_params_v; ++iv)
+            for (size_t j = 0; j < n_poles_v; ++j)
+                Mv(iv, j) = basis_function(v[iv], j, q, size_t{0}, k_flat_v);
+
+        auto lu_u = Mu.partialPivLu();
+        auto lu_v = Mv.partialPivLu();
+
+        std::vector<std::array<T, dim>> poles(n_poles);
+        MatrixX<T> Qd(n_poles_u, n_poles_v);
+        for (int d = 0; d < dim; ++d)
+        {
+            for (size_t iv = 0; iv < n_params_v; ++iv)
+                for (size_t iu = 0; iu < n_params_u; ++iu)
+                    Qd(iu, iv) = Q[iu + n_params_u * iv][d];
+
+            MatrixX<T> A  = lu_u.solve(Qd);              // Mu^-1 Q          (nu x nv)
+            MatrixX<T> Pt = lu_v.solve(A.transpose());   // P^T = Mv^-1 A^T  (nv x nu)
+
+            for (size_t j = 0; j < n_poles_v; ++j)
+                for (size_t i = 0; i < n_poles_u; ++i)
+                    poles[i + n_poles_u * j][d] = Pt(j, i);
+        }
+
+        return poles;
     }
 
     template <typename T, size_t dim>

--- a/tests/tests_bssurf.cpp
+++ b/tests/tests_bssurf.cpp
@@ -690,3 +690,49 @@ TEST(tests_bssurf, approx_constrained)
     if(PLOT_ON)
         gbs::plot(srf,pts);
 }
+
+// Grid (tensor-product) interpolation via the separable solver (issue #34, PR1):
+// (a) the produced poles must equal the previous dense Kronecker solve to ~1e-9,
+// and (b) the surface must interpolate the grid at the chosen params.
+TEST(tests_bssurf, grid_interp_separable_matches_dense)
+{
+    using T = double;
+    const size_t p = 3, q = 2;
+    const std::vector<T> u{0., 0.2, 0.55, 1.};   // nu = 4 (>= p+1)
+    const std::vector<T> v{0., 0.4, 1.};         // nv = 3 (>= q+1)
+    const size_t nu = u.size(), nv = v.size();
+    const auto ku = gbs::build_simple_mult_flat_knots<T>(u, p);
+    const auto kv = gbs::build_simple_mult_flat_knots<T>(v, q);
+
+    gbs::points_vector<T, 3> Q(nu * nv); // U-first storage: iu + nu*iv
+    for (size_t iv = 0; iv < nv; ++iv)
+        for (size_t iu = 0; iu < nu; ++iu)
+            Q[iu + nu * iv] = {u[iu], v[iv],
+                               0.3 + std::sin(2.0 * u[iu]) * std::cos(1.7 * v[iv])};
+
+    // Separable solver (the function under test).
+    auto poles = gbs::build_poles<T, 3>(Q, ku, kv, u, v, p, q);
+
+    // Dense reference: the previous path (full Kronecker matrix + dense LU).
+    gbs::MatrixX<T> N(nu * nv, nu * nv);
+    gbs::fill_poles_matrix(N, ku, kv, u, v, p, q);
+    auto lu = N.partialPivLu();
+    gbs::points_vector<T, 3> poles_ref(nu * nv);
+    for (int d = 0; d < 3; ++d)
+    {
+        gbs::VectorX<T> b(nu * nv);
+        for (size_t i = 0; i < nu * nv; ++i) b(i) = Q[i][d];
+        auto x = lu.solve(b);
+        for (size_t i = 0; i < nu * nv; ++i) poles_ref[i][d] = x(i);
+    }
+
+    for (size_t i = 0; i < nu * nv; ++i)
+        ASSERT_LT(gbs::norm(poles[i] - poles_ref[i]), 1e-9) << "pole " << i;
+
+    // Interpolation property: the surface passes through the grid points.
+    gbs::BSSurface<T, 3> srf(poles, ku, kv, p, q);
+    for (size_t iv = 0; iv < nv; ++iv)
+        for (size_t iu = 0; iu < nu; ++iu)
+            ASSERT_LT(gbs::norm(srf.value(u[iu], v[iv]) - Q[iu + nu * iv]), 1e-9)
+                << "u=" << u[iu] << " v=" << v[iv];
+}


### PR DESCRIPTION
First fix from #34. Replaces the dense solve of the tensor-product **surface interpolation** with a separable one.

## What

The grid collocation matrix is the Kronecker product `Mv ⊗ Mu`, so the system separates:

```
Q = Mu · P · Mv^T   ⇒   P = Mu⁻¹ · Q · Mv⁻ᵀ
```

`bssinterp.h` `build_poles` (grid path) now:
- assembles only the two small 1-D collocation matrices `Mu` (nu×nu) and `Mv` (nv×nv) — the `(nu·nv)²` Kronecker matrix is **never formed**;
- factors each once (`partialPivLu`), then solves `A = Mu⁻¹Q` then `Pᵀ = Mv⁻¹Aᵀ`.

Cost: dense `O((nu·nv)³)` → `~O(nu³+nv³)`; assembly `O((nu·nv)²)` → `O(nu²+nv²)`.

## Results (bidegree (3,3), clang-21 `-O3`)

| N (N×N grid) | before | after | speedup |
|------|--------|-------|---------|
| 8  | 0.35 ms | 0.034 ms | 10×   |
| 16 | 7.38 ms | 0.113 ms | 65×   |
| 24 | 95.8 ms | 0.208 ms | 460×  |
| 32 | 606 ms  | 0.413 ms | **1467×** |

Scaling ~N⁶ → ~N² (a 64×64 grid: ~30-40 s → ~1.6 ms). Curve numbers unchanged (untouched path). Full data in `bench/INTERP_AUDIT.md`; harness `bench/bench_interp.cpp`.

## Scope

Only the **grid/tensor** path — `build_poles(Q, ku, kv, u, v, p, q)`, also used by `loft`/`gordon` in `bssbuild.h`. The scattered-constraint surface builder and the surface **approximation** path (which reuse `fill_poles_matrix`, rectangular least-squares) are deliberately untouched. Plans #2 (band assembly + one-pass basis) and #3 (banded curve solve) of #34 remain as follow-ups.

## Correctness

- New `tests_bssurf.grid_interp_separable_matches_dense`: the produced poles equal the previous dense Kronecker solve to **1e-9**, and the surface interpolates the grid points.
- The existing `loft`/`bssbuild` tests already exercise this path end-to-end.
- **All 220 tests pass.**
