### PR TITLE
perf(interp): one-pass banded collocation assembly + coherence fixes (#34)

### DIFF
--- a/bench/INTERP_AUDIT.md
+++ b/bench/INTERP_AUDIT.md
@@ -93,7 +93,25 @@ The waste is purely structural: dense, full, recursive.
   Scaling went from ~N⁶ to ~N² (a 64×64 grid: ~30-40 s → ~1.6 ms). Poles match
   the old dense solve to ~1e-9 (`tests_bssurf.grid_interp_separable_matches_dense`).
   Curve numbers are unchanged (untouched path).
-- Plan #2 / #3 (band assembly + one-pass basis, banded curve solve) — TODO.
+- **Plan #2 (band assembly + one-pass basis) — DONE** (this branch). The
+  collocation matrices are now filled only on their non-zero band (`p+1` per row),
+  each row from one `basis_ders`/`ders_basis_funs` (A2.2/A2.3) pass instead of
+  `n_poles` recursive `basis_function` calls — in `build_poles_matrix`, both
+  curve scattered builders (`bscinterp.h`), the surface `Mu`/`Mv` (separable) and
+  the scattered surface builder. This removes the exponential-in-degree assembly
+  cost. Curve interpolation vs degree (n=200), total `interpolate()` ms:
+
+  | degree | 1 | 2 | 3 | 5 | 7 | 9 |
+  |--------|---|---|---|---|---|---|
+  | before | 3.2 | 3.5 | 4.2 | 8.9 | 23.6 | 87.0 |
+  | after  | 3.6 | 3.8 | 3.7 | 4.8 | 4.5 | 3.7 |
+
+  The `2^p` blow-up is gone — assembly is now flat in degree (**p9: 87 → 3.7 ms,
+  23×**); the residual ~3.7 ms is the dense `O(n³)` solve (addressed by plan #3).
+  Surface assembly gains a further ~1.3-2.5× on top of plan #1 (larger at high
+  bidegree). Matrices are identical to the dense fill, so poles are unchanged.
+- Plan #3 (banded curve solve `O(n·p²)`; the curve-vs-#points `O(n³)` cost, e.g.
+  800 pts ≈ 300 ms) — TODO.
 
 ## Recommended fixes (priority order)
 

--- a/gbs/basisfunctions.ixx
+++ b/gbs/basisfunctions.ixx
@@ -292,11 +292,14 @@
         {
             if (u < k[mid]) high = mid;
             else            low  = mid;
-            mid = (low + high) / 2;
-        }
+            auto next_mid = (low + high) / 2;
+            if (next_mid == mid) // no progress: u out of domain or degenerate
+                break;           // knot vector. Return the closest span instead
+            mid = next_mid;      // of looping forever (valid inputs converge
+        }                        // before this ever triggers).
         return std::next(k.begin(), mid);
     }
-    
+
     template <typename T>
     auto find_span2(size_t n, size_t p, T u, const std::vector<T> &k)
     {

--- a/gbs/bscinterp.h
+++ b/gbs/bscinterp.h
@@ -136,13 +136,11 @@ auto build_poles(const std::vector<constrPoint<T, dim>> &Q, const std::vector<T>
     //TODO sort Q by contrain order to get a block systen
     auto n_poles = Q.size();
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_poles, n_poles);
-    for (int i = 0; i < n_poles; i++) // Eigen::ColMajor is default
-    {
-        for (int j = 0; j < n_poles; j++)
-        {
-            N(i, j) = basis_function(Q[i].u, j, deg, Q[i].d, k_flat);
-        }
-    }
+    // Banded one-pass assembly: each constraint row has only deg+1 non-zero
+    // entries (the basis support), filled in a single basis pass.
+    N.setZero();
+    for (size_t i = 0; i < n_poles; ++i)
+        fill_basis_row(N, Eigen::Index(i), Q[i].u, k_flat, deg, Q[i].d);
     auto N_inv = N.partialPivLu();
     VectorX<T> b(n_poles);
     std::vector<std::array<T, dim>> poles(n_poles);
@@ -328,27 +326,14 @@ auto interpolate(const bsc_bound<T,dim> &pt_begin,const bsc_bound<T,dim> &pt_end
 
     auto k_flat = build_simple_mult_flat_knots(u,p);
 
+    // Banded one-pass assembly: each row (begin point, the derivative
+    // constraints, end point) has only p+1 non-zero entries.
     MatrixX<T> N(n,n);
-    for (auto j = 0; j < n; j++)
-    {
-        N(0, j) = basis_function(std::get<0>(pt_begin), j, p,0, k_flat);
-    }
-
-    for (int i = 0; i < nc; i++) // Eigen::ColMajor is default
-    {
-        auto u = std::get<0>(cstr_lst[i]);
-        auto d = std::get<2>(cstr_lst[i]);
-        for (auto j = 0; j < n; j++)
-        {
-            N(i + 1, j) = basis_function(u, j, p, d, k_flat);
-        }
-    }
-
-
-    for (auto j = 0; j < n; j++)
-    {
-        N(n-1, j) = basis_function(std::get<0>(pt_end), j, p,0, k_flat);
-    }
+    N.setZero();
+    fill_basis_row(N, Eigen::Index(0), std::get<0>(pt_begin), k_flat, p, size_t{0});
+    for (size_t i = 0; i < nc; ++i)
+        fill_basis_row(N, Eigen::Index(i + 1), std::get<0>(cstr_lst[i]), k_flat, p, std::get<2>(cstr_lst[i]));
+    fill_basis_row(N, Eigen::Index(n - 1), std::get<0>(pt_end), k_flat, p, size_t{0});
 
     auto N_inv = N.partialPivLu();
     // auto N_inv = N.colPivHouseholderQr();

--- a/gbs/bscurve.h
+++ b/gbs/bscurve.h
@@ -217,6 +217,17 @@ namespace gbs
         if(!ok)
         {
             std::cerr << "check_curve: incorrect poles/knots/degree combination\n";
+            return ok;
+        }
+        // A degree-p B-spline needs at least p+1 control points; otherwise the
+        // knot vector cannot be a valid (clamped) one. The size equation above is
+        // necessary but not sufficient — it passes for e.g. p=3 with 3 poles and
+        // 7 knots {0,0,0,1,1,1,1}, which is degenerate.
+        ok = ok && (np >= p + 1);
+        if(!ok)
+        {
+            std::cerr << "check_curve: a degree-" << p << " B-spline needs at least "
+                      << (p + 1) << " poles (got " << np << ")\n";
         }
         return ok;
     }

--- a/gbs/bssinterp.h
+++ b/gbs/bssinterp.h
@@ -119,14 +119,14 @@ namespace gbs
         // solves instead of one dense O((nu*nv)^3) LU (issue #34). Poles and Q
         // are stored U-first: index i + n_poles_u * j.
         MatrixX<T> Mu(n_poles_u, n_poles_u);
+        Mu.setZero();
         for (size_t iu = 0; iu < n_params_u; ++iu)
-            for (size_t i = 0; i < n_poles_u; ++i)
-                Mu(iu, i) = basis_function(u[iu], i, p, size_t{0}, k_flat_u);
+            fill_basis_row(Mu, Eigen::Index(iu), u[iu], k_flat_u, p, size_t{0});
 
         MatrixX<T> Mv(n_poles_v, n_poles_v);
+        Mv.setZero();
         for (size_t iv = 0; iv < n_params_v; ++iv)
-            for (size_t j = 0; j < n_poles_v; ++j)
-                Mv(iv, j) = basis_function(v[iv], j, q, size_t{0}, k_flat_v);
+            fill_basis_row(Mv, Eigen::Index(iv), v[iv], k_flat_v, q, size_t{0});
 
         auto lu_u = Mu.partialPivLu();
         auto lu_v = Mv.partialPivLu();
@@ -222,17 +222,40 @@ namespace gbs
         auto n = k_flat_u.size() - p - 1;
         auto m = k_flat_v.size() - q - 1;
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_poles, n_poles);
-        for (int k = 0; k < n_poles; k++) // Eigen::ColMajor is default
+        // Banded one-pass assembly: each constraint row is the outer product of
+        // the (p+1) non-zero u-basis derivatives and the (q+1) non-zero v-basis
+        // derivatives, evaluated with one basis pass per direction instead of
+        // n*m recursive basis_function pairs.
+        N.setZero();
+        for (size_t k = 0; k < n_poles; ++k)
         {
-            auto [u, v, x, du, dv] = Q[k];
-            for (int j{}; j < m; j++)
+            const auto &[u, v, x, du, dv] = Q[k];
+            if (du > p || dv > q)
+                continue; // identically-zero row
+            const size_t span_u = std::min<size_t>(find_span(n, p, u, k_flat_u) - k_flat_u.begin(), n - 1);
+            const size_t span_v = std::min<size_t>(find_span(m, q, v, k_flat_v) - k_flat_v.begin(), m - 1);
+            const size_t i_min = (span_u >= p) ? span_u - p : 0;
+            const size_t j_min = (span_v >= q) ? span_v - q : 0;
+            const size_t ii_max = (i_min + p < n) ? p : n - 1 - i_min; // clamp bands to poles
+            const size_t jj_max = (j_min + q < m) ? q : m - 1 - j_min;
+            if (p <= bspline_stack_max_degree && q <= bspline_stack_max_degree)
             {
-                for (int i{}; i < n; i++)
-                {
-                    auto l = i + n * j;
-                    N(k, l) = basis_function(u, i, p, du, k_flat_u) *
-                              basis_function(v, j, q, dv, k_flat_v);
-                }
+                T Nu[bspline_stack_max_degree + 1];
+                T Nv[bspline_stack_max_degree + 1];
+                basis_ders(span_u, p, du, u, k_flat_u, Nu);
+                basis_ders(span_v, q, dv, v, k_flat_v, Nv);
+                for (size_t jj = 0; jj <= jj_max; ++jj)
+                    for (size_t ii = 0; ii <= ii_max; ++ii)
+                        N(Eigen::Index(k), Eigen::Index((i_min + ii) + n * (j_min + jj))) = Nu[ii] * Nv[jj];
+            }
+            else
+            {
+                // Pathological degree: recursive fallback (still banded).
+                for (size_t jj = 0; jj <= jj_max; ++jj)
+                    for (size_t ii = 0; ii <= ii_max; ++ii)
+                        N(Eigen::Index(k), Eigen::Index((i_min + ii) + n * (j_min + jj))) =
+                            basis_function(u, i_min + ii, p, du, k_flat_u) *
+                            basis_function(v, j_min + jj, q, dv, k_flat_v);
             }
         }
 

--- a/gbs/knotsfunctions.ixx
+++ b/gbs/knotsfunctions.ixx
@@ -844,21 +844,75 @@
         return bezier_seg; // return the list of Bezier segments
     }
 
+    // One-pass, banded fill of one B-spline collocation row for a single
+    // derivative order: writes the p+1 non-zero basis-derivative values of order
+    // d at parameter u into row `row`, columns [span-p, span]. All other columns
+    // of that row must already be zero (caller does N.setZero()). Uses one
+    // basis_ders (A2.2/A2.3) pass instead of n_poles recursive basis_function
+    // calls — the basis support is exactly [span-p, span], so the result is
+    // identical to the dense fill, just without the (exact-zero) off-band work.
+    template <typename T>
+    auto fill_basis_row(MatrixX<T> &N, Eigen::Index row, T u, const std::vector<T> &k, size_t p, size_t d) -> void
+    {
+        if (d > p)
+            return; // derivative order above degree => row is identically zero
+        const size_t n_poles = k.size() - p - 1;
+        size_t span = find_span(n_poles, p, u, k) - k.begin();
+        span = std::min(span, n_poles - 1);
+        const size_t i_min = (span >= p) ? span - p : 0;
+        const size_t r_max = (i_min + p < n_poles) ? p : n_poles - 1 - i_min; // clamp band to columns
+        if (p <= bspline_stack_max_degree)
+        {
+            T Nd[bspline_stack_max_degree + 1];
+            basis_ders(span, p, d, u, k, Nd);
+            for (size_t r = 0; r <= r_max; ++r)
+                N(row, Eigen::Index(i_min + r)) = Nd[r];
+        }
+        else
+        {
+            for (size_t r = 0; r <= r_max; ++r)
+                N(row, Eigen::Index(i_min + r)) = basis_function(u, i_min + r, p, d, k);
+        }
+    }
+
+    // One-pass, banded fill of a contiguous block of derivative orders 0..d_max
+    // for parameter u: order d -> row (row0 + d), columns [span-p, span]. A single
+    // ders_basis_funs (A2.3) pass yields every order at once. Other columns must
+    // be pre-zeroed.
+    template <typename T>
+    auto fill_basis_band(MatrixX<T> &N, Eigen::Index row0, T u, const std::vector<T> &k, size_t p, size_t d_max) -> void
+    {
+        const size_t n_poles = k.size() - p - 1;
+        size_t span = find_span(n_poles, p, u, k) - k.begin();
+        span = std::min(span, n_poles - 1);
+        const size_t i_min = (span >= p) ? span - p : 0;
+        const size_t dd = std::min(d_max, p); // orders above degree are zero
+        const size_t r_max = (i_min + p < n_poles) ? p : n_poles - 1 - i_min; // clamp band to columns
+        if (p <= bspline_stack_max_degree)
+        {
+            T ders[(bspline_stack_max_degree + 1) * (bspline_stack_max_degree + 1)];
+            ders_basis_funs(span, p, dd, u, k, ders);
+            for (size_t d = 0; d <= dd; ++d)
+                for (size_t r = 0; r <= r_max; ++r)
+                    N(row0 + Eigen::Index(d), Eigen::Index(i_min + r)) = ders[d * (p + 1) + r];
+        }
+        else
+        {
+            for (size_t d = 0; d <= dd; ++d)
+                for (size_t r = 0; r <= r_max; ++r)
+                    N(row0 + Eigen::Index(d), Eigen::Index(i_min + r)) = basis_function(u, i_min + r, p, d, k);
+        }
+    }
+
     template <typename T, size_t nc>
     auto build_poles_matrix(const std::vector<T> &k_flat, const std::vector<T> &u, size_t deg, size_t n_poles, MatrixX<T> &N) -> void
     {
-        auto n_params = int(u.size());
-
-        for (int i = 0; i < n_params; i++)
-        {
-            for (int j = 0; j < n_poles; j++)
-            {
-                for (int deriv = 0; deriv < nc; deriv++)
-                {
-                    N(nc * i + deriv, j) = basis_function(u[i], j, deg, deriv, k_flat);
-                }
-            }
-        }
+        // Banded one-pass assembly: each parameter contributes nc contiguous rows
+        // (derivative orders 0..nc-1), each with only deg+1 non-zero entries.
+        N.setZero();
+        const size_t n_params = u.size();
+        for (size_t i = 0; i < n_params; ++i)
+            fill_basis_band(N, Eigen::Index(nc * i), u[i], k_flat, deg, nc - 1);
     }
     template <typename T, size_t dim>
     auto increase_degree(std::vector<T> &k, std::vector<std::array<T, dim>> &poles,size_t p, size_t t)

--- a/gbs/loft/loftGeneric.h
+++ b/gbs/loft/loftGeneric.h
@@ -78,6 +78,12 @@ namespace gbs{
     auto loft_generic(InputIt first, InputIt last, const std::vector<T> &v, size_t q)
     {
         auto curves_info = get_bs_curves_info<T, dim>(first, last);
+        // A degree-q loft needs at least q+1 sections; clamp so we never build a
+        // degenerate v-direction (consistent with the q_max overloads). The
+        // clamped q is used for BOTH the knot vector and the surface ctor.
+        const size_t n_sections = curves_info.size();
+        if (n_sections > 0)
+            q = std::min(q, n_sections - 1);
         auto [poles, flat_u, flat_v, p] = loft(curves_info, v, q);
 
         using CurveType = typename std::iterator_traits<InputIt>::value_type;

--- a/tests/tests_bscurve.cpp
+++ b/tests/tests_bscurve.cpp
@@ -234,6 +234,20 @@ TEST(tests_bscurve, eval_except)
     ASSERT_THROW(crv.value(2.), gbs::OutOfBoundsCurveEval<double>);
 }
 
+// A degree-p B-spline needs at least p+1 poles. The size equation
+// (p+1+np == #knots) alone is not sufficient: p=3 with 3 poles and the
+// degenerate knot vector {0,0,0,1,1,1,1} (7 knots) satisfies it yet is
+// incoherent. check_curve must reject it so the constructor throws rather than
+// silently building an unusable curve (which later hung find_span).
+TEST(tests_bscurve, ctor_rejects_too_few_poles)
+{
+    using T = double;
+    std::vector<T> k = {0.,0.,0.,1.,1.,1.,1.};
+    std::vector<std::array<T,3>> poles = {{0.,0.,0.}, {1.,0.,0.}, {1.,1.,0.}};
+    ASSERT_EQ(poles.size(), k.size() - 3 - 1); // size equation holds (np == 3)
+    ASSERT_THROW((gbs::BSCurve<T,3>(poles, k, 3)), std::invalid_argument);
+}
+
 TEST(tests_bscurve, d_dm_vectorized)
 {
     using T = double;


### PR DESCRIPTION
Plan #2 of #34: one-pass **banded** collocation assembly for B-spline interpolation, plus the coherence/robustness fixes surfaced while testing it.

## Assembly (perf)

The collocation matrices were filled over **all `n²` entries** with the recursive (exponential-in-degree) `basis_function`. Now each row is filled only on its **non-zero band** (`p+1` entries), from a single `basis_ders`/`ders_basis_funs` (A2.2/A2.3) pass — new helpers `fill_basis_row` / `fill_basis_band` in `knotsfunctions.ixx`. Applied to `build_poles_matrix`, both curve scattered builders (`bscinterp.h`), the separable surface `Mu`/`Mv` and the scattered surface builder (`bssinterp.h`).

The basis support is exactly `[span-p, span]`, so the assembled matrices are **identical** to the dense fill — poles unchanged.

Curve interpolation vs degree (n=200, total `interpolate()` ms):

| degree | 1 | 2 | 3 | 5 | 7 | 9 |
|--------|---|---|---|---|---|---|
| before | 3.2 | 3.5 | 4.2 | 8.9 | 23.6 | 87.0 |
| after  | 3.6 | 3.8 | 3.7 | 4.8 | 4.5 | 3.7 |

The `2^p` blow-up is gone — assembly is flat in degree (**p9: 87 → 3.7 ms, 23×**); the residual is the dense `O(n³)` solve (plan #3). Surface assembly gains a further ~1.3–2.5× on top of the separable solve (#35).

## Root-cause / robustness fixes

Testing the banded path exposed a pre-existing latent bug: `tests_bssbuild.loft_rational` builds a **degenerate** curve (degree 3 with 3 poles, knots `{0,0,0,1,1,1,1}`) that was silently accepted, and the new `find_span`-based assembly **hung** on it (68 min). Treated at the root:

- **`check_curve` now rejects `np < p+1`.** The size equation `p+1+np == #knots` is necessary but not sufficient (the degenerate curve above satisfies it). The curve/surface constructor now throws `std::invalid_argument` on incoherent input instead of silently accepting it. Test: `tests_bscurve.ctor_rejects_too_few_poles`.
- **`loft_generic` clamps the v-degree to `n_sections-1`** (consistent with its `q_max` overloads) and propagates the clamped degree to the surface constructor, so `loft` no longer *generates* a degenerate curve.
- **`find_span` no longer infinite-loops** on out-of-domain `u` / degenerate knots — it breaks when the bisection can't progress (no-op for valid inputs; a search primitive shouldn't hang).
- Band fills are clamped to the actual pole count (no overrun if ever fed bad knots).

## Tests

- New `tests_bscurve.ctor_rejects_too_few_poles` locks in the constructor check.
- `loft_rational` now passes in 0 ms (was hanging).
- The stricter `check_curve` broke no other test.
- **All 221 tests pass.**

Remaining in #34: plan #3 (banded curve solve `O(n·p²)`; curve-vs-#points is still dense `O(n³)`).
