### PR TITLE
perf(interp): banded sparse solve for curve interpolation (#34, plan #3)

### DIFF
--- a/bench/INTERP_AUDIT.md
+++ b/bench/INTERP_AUDIT.md
@@ -110,8 +110,25 @@ The waste is purely structural: dense, full, recursive.
   23×**); the residual ~3.7 ms is the dense `O(n³)` solve (addressed by plan #3).
   Surface assembly gains a further ~1.3-2.5× on top of plan #1 (larger at high
   bidegree). Matrices are identical to the dense fill, so poles are unchanged.
-- Plan #3 (banded curve solve `O(n·p²)`; the curve-vs-#points `O(n³)` cost, e.g.
-  800 pts ≈ 300 ms) — TODO.
+- **Plan #3 (banded curve solve) — DONE** (this branch). The sorted curve
+  interpolation `build_poles` (`constrType` path, used by
+  `interpolate(points, p, mode)`) now solves the banded collocation matrix with
+  `Eigen::SparseLU` under **natural ordering** (preserves the band → `O(n·p²)`)
+  instead of the dense `O(n³)` `partialPivLu`. Factorization is reused across the
+  `dim` components. Curve interpolation vs #points (degree 3, total
+  `interpolate()` ms):
+
+  | n_points | before | after | speedup |
+  |----------|--------|-------|---------|
+  | 200 | ~3.3 ms | 0.44 ms | ~7.5× |
+  | 400 | ~21 ms  | 1.04 ms | ~20×  |
+  | 800 | ~270 ms | 4.53 ms | ~60×  |
+
+  Scaling is now ~linear in n instead of `O(n³)`; no small-n regression. Combined
+  with plan #2 the n=200 degree sweep is now ~0.34–0.51 ms flat (was 3.3 ms+).
+  Scope: the **sorted** interpolation path. The scattered-constraint curve
+  builders (`constrPoint`, `bsc_constraint`) stay dense (not banded without
+  sorting — the existing `//TODO sort Q` follow-up).
 
 ## Recommended fixes (priority order)
 

--- a/gbs/bscinterp.h
+++ b/gbs/bscinterp.h
@@ -2,6 +2,8 @@
 
 #include <gbs/execution.h>
 #include <Eigen/Dense>
+#include <Eigen/SparseCore>
+#include <Eigen/SparseLU>
 #include <gbs/bscurve.h>
 
 #ifdef GBS_USE_MODULES
@@ -99,12 +101,19 @@ template <typename T,size_t dim,size_t nc>
 
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_poles, n_poles);
 
-
     build_poles_matrix<T,nc>(k_flat,u,deg,n_poles,N);
-    auto N_inv = N.partialPivLu(); //TODO solve block system
-    // auto N_inv = N.colPivHouseholderQr(); //TODO solve block system
 
-    // std::cout << N << std::endl;
+    // The collocation matrix is banded (sorted parameters + simple knots: each
+    // row's non-zeros lie in [span-p, span], and the span is non-decreasing).
+    // Solve it with a sparse LU using NATURAL ordering, which preserves the band
+    // -> O(n*p^2) factorization instead of the dense O(n^3) partialPivLu. This is
+    // the lever for large point counts (issue #34, plan #3). The factorization is
+    // reused across the `dim` spatial components.
+    Eigen::SparseMatrix<T> Ns = N.sparseView();
+    Ns.makeCompressed();
+    Eigen::SparseLU<Eigen::SparseMatrix<T>, Eigen::NaturalOrdering<int>> solver;
+    solver.analyzePattern(Ns);
+    solver.factorize(Ns);
 
     std::vector<std::array<T, dim>> poles(n_poles);
 
@@ -119,7 +128,7 @@ template <typename T,size_t dim,size_t nc>
             }
         }
 
-        auto x = N_inv.solve(b);
+        VectorX<T> x = solver.solve(b);
 
         for (int i = 0; i < n_poles; i++)
         {

--- a/tests/tests_bsinterp.cpp
+++ b/tests/tests_bsinterp.cpp
@@ -341,3 +341,23 @@ TEST(tests_bscurve, perf_build_poles_unif_constr)
     );
     
 }
+// Large-count curve interpolation goes through the banded sparse solve
+// (issue #34, plan #3). Verify the curve interpolates all 201 points to
+// tolerance — i.e. the SparseLU solve matches the data, at a size where the
+// old dense O(n^3) factorization dominated.
+TEST(tests_bsinterp, large_point_interpolation_banded)
+{
+    using T = double;
+    const size_t n = 201, p = 3;
+    gbs::points_vector<T, 3> pts(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        T t = T(i) / T(n - 1);
+        pts[i] = {std::cos(6.0 * t), std::sin(6.0 * t), 2.0 * t};
+    }
+    auto crv = gbs::interpolate(pts, p, gbs::KnotsCalcMode::CHORD_LENGTH);
+    auto u = gbs::curve_parametrization(pts, gbs::KnotsCalcMode::CHORD_LENGTH, true);
+    ASSERT_EQ(u.size(), n);
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_LT(gbs::distance(crv.value(u[i]), pts[i]), 1e-9) << "i=" << i;
+}


### PR DESCRIPTION
Plan #3 of #34 — the last piece. Motivated by your **201-point** interpolation: that's exactly where the dense `O(n³)` solve dominated.

## What

The sorted curve-interpolation collocation matrix is **banded** (each row's non-zeros lie in `[span-p, span]`, and the span is non-decreasing). `build_poles` (the `constrType` path used by `interpolate(points, p, mode)`) now solves it with `Eigen::SparseLU` under **natural ordering** — which preserves the band, giving `O(n·p²)` — instead of the dense `O(n³)` `partialPivLu`. The factorization is reused across the `dim` spatial components.

## Results (degree 3, clang-21 `-O3`, total `interpolate()` ms)

| n_points | before (dense) | after (sparse) | speedup |
|----------|----------------|----------------|---------|
| 200 | ~3.3 ms | **0.44 ms** | ~7.5× |
| 400 | ~21 ms  | 1.04 ms | ~20×  |
| 800 | ~270 ms | 4.53 ms | ~60×  |

Your 201-point case: ~3.3 ms → **~0.44 ms**. Scaling is now ~linear in n (was `O(n³)`); no small-n regression. Combined with #36, the n=200 degree sweep is ~0.34–0.51 ms flat.

## Scope

Only the **sorted** interpolation path. The scattered-constraint curve builders (`constrPoint`, `bsc_constraint`) stay dense — they aren't banded without sorting first (the existing `//TODO sort Q` follow-up). Surface paths are unchanged (already separable via #35).

## Correctness

- New `tests_bsinterp.large_point_interpolation_banded`: interpolates **201 points** (degree 3) and checks the curve passes through all of them to 1e-9 — directly validating the SparseLU solve at your target size.
- The solver change broke no caller (loft, bsctools, mesh, …): **all 221 prior tests pass**.

This completes the three planned fixes for #34 (separable surface #35, banded assembly #36, banded curve solve here).
