### PR TITLE
perf(interp): sparse solve for scattered-constraint interpolation (#34)

### DIFF
--- a/gbs/bscinterp.h
+++ b/gbs/bscinterp.h
@@ -28,6 +28,38 @@ struct constrPoint
     size_t d;
 };
 
+// Below this number of unknowns a dense LU beats a sparse one: SparseLU's
+// symbolic analysis + fill-reducing ordering have a fixed overhead that dominates
+// for small systems. Above it, the banded collocation sparsity (only p+1 non-zero
+// entries per row, from the one-pass assembly) makes the sparse solve much
+// cheaper than the dense O(n^3) factorization. Keeps small interpolations on the
+// dense path so they are never penalized.
+inline constexpr Eigen::Index interp_sparse_threshold = 100;
+
+/**
+ * @brief Solve the collocation system N * X = B for all dim right-hand sides,
+ *        choosing a dense or sparse LU by problem size.
+ *
+ * The collocation matrix is assembled banded (p+1 non-zeros per row). For large
+ * systems an Eigen::SparseLU with a fill-reducing ordering exploits that sparsity
+ * (~O(n*p^2)); for small systems a dense partialPivLu is faster and is kept to
+ * avoid any regression on low point counts. The factorization is computed once
+ * and reused across the dim columns of B.
+ */
+template <typename T>
+auto solve_collocation(const MatrixX<T> &N, const MatrixX<T> &B) -> MatrixX<T>
+{
+    if (N.rows() < interp_sparse_threshold)
+        return N.partialPivLu().solve(B);
+
+    Eigen::SparseMatrix<T> Ns = N.sparseView();
+    Ns.makeCompressed();
+    Eigen::SparseLU<Eigen::SparseMatrix<T>> solver;
+    solver.analyzePattern(Ns);
+    solver.factorize(Ns);
+    return solver.solve(B);
+}
+
 template <typename T, size_t dim>
 auto build_3pt_tg_vec(const std::vector<std::array<T, dim>> &pts,const std::vector<T> &u)
 {
@@ -142,31 +174,28 @@ template <typename T,size_t dim,size_t nc>
 template <typename T, size_t dim>
 auto build_poles(const std::vector<constrPoint<T, dim>> &Q, const std::vector<T> &k_flat, size_t deg) -> std::vector<std::array<T, dim>>
 {
-    //TODO sort Q by contrain order to get a block systen
     auto n_poles = Q.size();
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_poles, n_poles);
     // Banded one-pass assembly: each constraint row has only deg+1 non-zero
-    // entries (the basis support), filled in a single basis pass.
+    // entries (the basis support), filled in a single basis pass. The rows may be
+    // in any constraint order, but the matrix is still sparse (p+1 nnz/row), so a
+    // sparse LU with fill-reducing ordering solves it efficiently above the size
+    // threshold — no explicit sort needed (the ordering does the work).
     N.setZero();
     for (size_t i = 0; i < n_poles; ++i)
         fill_basis_row(N, Eigen::Index(i), Q[i].u, k_flat, deg, Q[i].d);
-    auto N_inv = N.partialPivLu();
-    VectorX<T> b(n_poles);
+
+    MatrixX<T> B(n_poles, dim);
+    for (size_t i = 0; i < n_poles; ++i)
+        for (size_t d = 0; d < dim; ++d)
+            B(Eigen::Index(i), Eigen::Index(d)) = Q[i].v[d];
+
+    MatrixX<T> X = solve_collocation(N, B);
+
     std::vector<std::array<T, dim>> poles(n_poles);
-    for (int d = 0; d < dim; d++)
-    {
-        for (int i = 0; i < n_poles; i++)
-        {
-            b(i) = Q[i].v[d];
-        }
-
-        auto x = N_inv.solve(b);
-
-        for (int i = 0; i < n_poles; i++)
-        {
-            poles[i][d] = x(i);
-        }
-    }
+    for (size_t i = 0; i < n_poles; ++i)
+        for (size_t d = 0; d < dim; ++d)
+            poles[i][d] = X(Eigen::Index(i), Eigen::Index(d));
 
     return poles;
 }

--- a/gbs/bssinterp.h
+++ b/gbs/bssinterp.h
@@ -259,24 +259,19 @@ namespace gbs
             }
         }
 
-        auto N_inv = N.partialPivLu();
+        // Sparse for large constraint sets (each row has only (p+1)(q+1) non-zero
+        // entries), dense below the threshold. See solve_collocation.
+        MatrixX<T> B(n_poles, dim);
+        for (size_t i = 0; i < n_poles; ++i)
+            for (size_t d = 0; d < dim; ++d)
+                B(Eigen::Index(i), Eigen::Index(d)) = std::get<2>(Q[i])[d];
 
-        VectorX<T> b(n_poles);
+        MatrixX<T> X = solve_collocation(N, B);
+
         std::vector<std::array<T, dim>> poles(n_poles);
-        for (int d = 0; d < dim; d++)
-        {
-            for (int i = 0; i < n_poles; i++)
-            {
-                b(i) = std::get<2>(Q[i])[d];
-            }
-
-            auto x = N_inv.solve(b);
-
-            for (int i = 0; i < n_poles; i++)
-            {
-                poles[i][d] = x(i);
-            }
-        }
+        for (size_t i = 0; i < n_poles; ++i)
+            for (size_t d = 0; d < dim; ++d)
+                poles[i][d] = X(Eigen::Index(i), Eigen::Index(d));
 
         return poles;
     }

--- a/tests/tests_bsinterp.cpp
+++ b/tests/tests_bsinterp.cpp
@@ -361,3 +361,26 @@ TEST(tests_bsinterp, large_point_interpolation_banded)
     for (size_t i = 0; i < n; ++i)
         ASSERT_LT(gbs::distance(crv.value(u[i]), pts[i]), 1e-9) << "i=" << i;
 }
+
+// Large scattered constraint set exercises the sparse branch of
+// build_poles(constrPoint) (issue #34): above the size threshold it solves with
+// a sparse LU. Verify the curve interpolates all constraints to tolerance.
+TEST(tests_bsinterp, scattered_constr_points_sparse_path)
+{
+    using T = double;
+    const size_t n = 201, p = 3;
+    std::vector<T> u(n);
+    std::vector<gbs::constrPoint<T, 3>> Q(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        T t = T(i) / T(n - 1);
+        u[i] = t;
+        Q[i] = gbs::constrPoint<T, 3>{ {std::cos(6.0 * t), std::sin(6.0 * t), 2.0 * t}, t, 0 };
+    }
+    auto k = gbs::build_simple_mult_flat_knots<T>(u, p);
+    auto poles = gbs::build_poles(Q, k, p); // n >= threshold -> sparse path
+    ASSERT_EQ(poles.size(), n);
+    gbs::BSCurve<T, 3> crv(poles, k, p);
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_LT(gbs::distance(crv.value(u[i]), Q[i].v), 1e-9) << "i=" << i;
+}


### PR DESCRIPTION
Follow-up to #34: give the **scattered-constraint** interpolation builders the same sparse-solve benefit as the sorted ones — **without penalizing small interpolations**.

## What

`build_poles(constrPoint)` (curve) and `build_poles(bss_constraint)` (surface) solved their collocation matrix with a dense `partialPivLu`. Each row is sparse (`p+1` / `(p+1)(q+1)` non-zeros, from the #36 one-pass assembly), so:

- new `solve_collocation(N, B)` helper (`bscinterp.h`) picks the solver **by size**: dense `partialPivLu` below `interp_sparse_threshold` (= 100), `Eigen::SparseLU` above. No explicit sort is needed — SparseLU's fill-reducing ordering handles the arbitrary constraint order (the existing `//TODO sort Q` is thus moot).
- all `dim` right-hand sides are solved in one shot (one factorization reused).

**Small interpolations are not penalized** — below the threshold the path is the unchanged dense solve.

## Correctness

- New `tests_bsinterp.scattered_constr_points_sparse_path`: 201 scattered points, exercises the sparse branch, checks pass-through to 1e-9.
- Existing (small) scattered interpolations stay on the dense path — unchanged.
- Builder **signatures are unchanged** → Python bindings unaffected.

## Notes

- The `interp_sparse_threshold = 100` constant is a tuning value; tracked for centralization in **#38** (avoid magic numbers / single constants file).
- A further micro-opt — assembling the large-`n` matrix **directly as sparse triplets** instead of dense→`sparseView` (removes an `O(n²)` intermediate) — only pays off beyond a few thousand poles and is best done as a unified pass across all builders after the in-flight perf PRs merge. Deferred (noted in #34).
- Independent of #37 (sorted path) — different functions, no conflict.
