### PR TITLE
fix: VTK deprecated warnings in curve renderer

### DIFF
--- a/gbs-render/vtkcurvesrender.cpp
+++ b/gbs-render/vtkcurvesrender.cpp
@@ -120,14 +120,19 @@ namespace gbs
             }
         }
         vtkPolyData *polyData = dynamic_cast<vtkPolyData *>(actor->GetMapper()->GetInput());
+        if (!polyData)
+        {
+            vtkGenericWarningMacro("Failed to cast to vtkPolyData. Ensure the input is of the correct type.");
+            return;
+        }
 
         // Create texture coordinates
         tcoords->SetNumberOfComponents(1);
         tcoords->SetNumberOfTuples(polyData->GetNumberOfPoints());
+
         for (int i = 0; i < polyData->GetNumberOfPoints(); ++i)
         {
-            double value[1] = { static_cast<double>(i) * .5 };
-            tcoords->SetTypedTuple(i, value);
+            tcoords->SetTypedComponent(i, 0, static_cast<double>(i * 0.5));
         }
 
         polyData->GetPointData()->SetTCoords(tcoords);


### PR DESCRIPTION
## Résumé

Mini PR pour synchroniser `master` avec le commit local resté en avance sur `origin/master`.

Corrige les avertissements de dépréciation dans `gbs-render/vtkcurvesrender.cpp` :
- Ajout d'une vérification du `dynamic_cast` vers `vtkPolyData` (retour anticipé + warning si échec)
- Remplacement de `SetTypedTuple` par `SetTypedComponent` pour le réglage des coordonnées de texture

## Test
- [x] Compilation locale
