### PR TITLE
test(coverage): baseline + close edge-case gaps on eval/interp (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,11 @@ __pycache__/
 .Python
 build/
 build-conda/
+build-cov/
+
+# Coverage instrumentation (GBS_COVERAGE / scripts/coverage.sh)
+*.profraw
+*.profdata
 develop-eggs/
 dist/
 downloads/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,18 @@ option(GBS_USE_MODULES "Use C++20 modules" OFF)
 option(GBS_USE_OCCT_UTILS "Enable OpenCASCADE utilities" OFF)
 option(GBS_BUILD_STUBS "Automatically build python hints" ON)
 option(GBS_BUILD_DOC "Build documentation" OFF)
+option(GBS_COVERAGE "Instrument the test suite for source-based code coverage (Clang)" OFF)
+
+# Source-based coverage (clang `-fprofile-instr-generate -fcoverage-mapping`).
+# Off by default; flipping it on only adds instrumentation to the test
+# executables (see the gbs_testing target below) so a normal build is untouched.
+# Reproduce a report with scripts/coverage.sh (see bench/COVERAGE_AUDIT.md).
+if(GBS_COVERAGE)
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        message(FATAL_ERROR "GBS_COVERAGE requires a Clang toolchain (source-based coverage).")
+    endif()
+    message(STATUS "GBS coverage instrumentation enabled (test executables only).")
+endif()
 
     
 # Core header-only interface target
@@ -209,6 +221,14 @@ if(GBS_BUILD_TESTS)
     target_include_directories(gbs_testing INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/testing)
     target_sources(gbs_testing INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/testing/doctest_main.cpp)
     target_link_libraries(gbs_testing INTERFACE doctest::doctest)
+
+    # Coverage instrumentation rides on gbs_testing so every test executable that
+    # links it gets `-fprofile-instr-generate -fcoverage-mapping` (compile + link),
+    # while non-test targets (python bindings, render, ...) stay uninstrumented.
+    if(GBS_COVERAGE)
+        target_compile_options(gbs_testing INTERFACE -fprofile-instr-generate -fcoverage-mapping)
+        target_link_options(gbs_testing INTERFACE -fprofile-instr-generate -fcoverage-mapping)
+    endif()
 
     enable_testing()
 

--- a/bench/COVERAGE_AUDIT.md
+++ b/bench/COVERAGE_AUDIT.md
@@ -1,0 +1,164 @@
+# Test-coverage audit — core evaluation / interpolation (issue #50)
+
+Baseline of source-based test coverage for the library core, with the untested
+branches ranked and the cheap boundary gaps closed in this same PR. Motivation:
+the last two bugs (#46 OOB at `u == last knot`, #48 non-robust `in_circle`) were
+edge cases no test exercised — this enumerates the rest *before* they bite and
+gives a safety net for the loft refactor (#40).
+
+Tracked under epic #44. Analysis + test-adding only: no core algorithm logic is
+touched, so it is parallel-safe with the code PRs.
+
+## How it is measured
+
+Clang source-based coverage (`-fprofile-instr-generate -fcoverage-mapping`),
+off by default behind the `GBS_COVERAGE` CMake option so a normal build is
+untouched. Instrumentation rides on the `gbs_testing` interface target, so only
+the test executables are instrumented (not the python bindings / render libs).
+
+Reproduce from scratch:
+
+```sh
+scripts/coverage.sh          # configure build-cov/ (clang-21) + build + run + report
+scripts/coverage.sh --report # re-run + re-aggregate only (binaries already built)
+```
+
+or, in an already-configured `-DGBS_COVERAGE=ON` tree:
+
+```sh
+cmake --build build-cov --target coverage
+```
+
+Outputs land in `build-cov/coverage/`: `report.txt` (all `gbs/` headers),
+`report_core.txt` (the priority perimeter below), `annotated_core.txt`
+(line/branch-annotated source), `merged.profdata`.
+
+### Two things the harness does, and why
+
+- **Runs are pinned to one core** (`taskset -c 0`). The evaluators use
+  `std::execution::par` (TBB); with instrumentation the per-region profile
+  counters become cache-line-contended across all workers, so a millisecond
+  parallel sweep balloons to *minutes* of 60-core thrash. Coverage is
+  timing-independent, so serializing gives identical coverage in seconds.
+- **Micro-benchmarks are excluded** (`-tce=*perf*,cpp_algo.par_vs_seq,tests_bscurve.curve_reparametrized`).
+  They only re-run already-covered paths millions of times (10M curve evals,
+  100M-element `std::transform`, a 1080-sample arc-length integration). Under
+  instrumentation they dominate wall-clock and add no new coverage. Their one
+  real cost to this baseline: `curve_reparametrized` was the only caller of some
+  `bsctools.h` arc-length branches, which is why `bsctools.h` branch coverage
+  (73.5%) lags its line coverage (97.3%).
+
+Scope of the run: the eval/interp/loft test executables
+(`tests_basisfunctions`, `tests_bscurve`, `tests_bssurf`,
+`tests_curve_derivatives`, `tests_surface_derivatives`, `tests_curves`,
+`tests_surfaces`, `tests_bsinterp`, `tests_knotsfunctions`, `tests_bssbuild`,
+`tests_bsctools`). Coverage of a header is the union over all of these.
+
+## Baseline — priority perimeter
+
+`before` = master at the start of this PR; `after` = with the edge-case tests
+added below. Region / line / branch %.
+
+| File | regions | lines | branches | before→after (region) |
+|------|--------:|------:|---------:|----------------------|
+| `basisfunctions.ixx` | 81.0% | 88.2% | 76.1% | 80.3 → **81.0** |
+| `bscurve.h`          | 92.9% | 95.5% | 73.3% | 89.4 → **92.9** |
+| `bssurf.h`           | 88.0% | 91.2% | 70.5% | 85.4 → **88.0** |
+| `bscinterp.h`        | 97.7% | 93.1% | 95.5% | 96.6 → **97.7** |
+| `bssinterp.h`        | 86.2% | 86.0% | 74.3% | 84.5 → **86.2** |
+| `knotsfunctions.ixx` | 90.6% | 93.7% | 83.1% | 90.6 (—) |
+| `bssbuild.h`         | 95.8% | 97.2% | 89.3% | 95.8 (—) |
+| `bsctools.h`         | 92.1% | 97.3% | 73.5% | 92.1 (—) |
+| **TOTAL (perimeter)**| **88.6%** | **93.0%** | **78.3%** | 87.5 → **88.6** |
+
+For context, the whole `gbs/` tree (all headers reachable from the run) sits at
+**84.2% region / 81.5% line / 76.0% branch**. The lowest secondary files are the
+non-B-spline curve types (`curveonsurface.h` 50%, `curvecomposite.h` 58%,
+`curveline.h` 54%, `curvecircle.h` 69%) — out of this audit's eval/interp scope.
+
+## Ranked gaps and disposition
+
+Legend: **[fixed]** test added in this PR · **[intentional]** correct path left
+uncovered on purpose, with rationale · **[defer #40]** belongs to the loft work.
+
+### Tier 1 — eval / span / basis
+
+1. **High-degree (p > 24) recursive fallback** — `basisfunctions.ixx`
+   L386–391 (curve value), L435–441 (curve all-orders ders), L469–470 (rational
+   ders, keyed on derivative *order* n > 24), L548–560 (surface ders), L756–764
+   (surface value); mirrored in `bssinterp.h` L254–258 and `knotsfunctions.ixx`
+   L872–873 / L899–901 (`fill_basis_row[s]`). **[intentional]** Every fast
+   evaluator falls back to the recursive `basis_function` above
+   `bspline_stack_max_degree = 24`. That kernel is **O(2^p)**, so a degree-25
+   test costs ~26·2²⁵ ≈ 10⁹ ops *per evaluation* — it would re-introduce exactly
+   the kind of multi-minute test this audit removed. Real CAD/CAM degrees are
+   ≤ ~7; this branch is a "never silently break" guard, not a likely bug source.
+   Best closed (if ever) by a single low-`u`-count smoke test gated out of the
+   default run, not added here.
+2. **Degenerate weight → origin** in `weight_projection` (L808–816, the zero-
+   weight branch). **[fixed]** `weight_projection_zero_weight_is_origin`.
+3. **`find_span` out-of-domain "no progress" break** (L306–308). **[fixed]**
+   `find_span_out_of_domain_below` (u below the first knot returns span `p`).
+4. **Degree 0 / degree 1 evaluation** never went through the fast path.
+   **[fixed]** `eval_degree_0_and_1` (piecewise-constant + control polyline,
+   value and derivative).
+5. **Out-of-domain evaluation throws** — `bscurve.h` L603 (`BSCurve::derivatives`),
+   L643/L651 (rational value/derivatives). Only `BSCurve::value` was pinned.
+   **[fixed]** `tests_bscurve.eval_out_of_bounds_throws`.
+6. **`check_curve` validation** — `bscurve.h` L213–214 (unordered knots),
+   L219–220 (size equation). The `np ≥ p+1` guard was already tested
+   (`ctor_rejects_too_few_poles`); these two siblings were not. **[fixed]**
+   `ctor_rejects_unordered_and_wrong_size_knots`.
+7. **Pole / knot mutation guards** — `bscurve.h` L472/L487 (`pole(id)` OOB),
+   L458 (`movePoles`), L499 (`copyKnots`), L556–557 (`changeBounds(k1,k2)`).
+   **[fixed]** `pole_and_buffer_guards`.
+8. **Surface OOB / validation** — `bssurf.h` L438/L440/L442 (ctor: pole count,
+   U knots, V knots), L1093/L1095 (`value` U/V OOB). **[fixed]**
+   `tests_bssurf.ctor_rejects_invalid`, `eval_out_of_bounds_throws`.
+
+   Still open (cheap, low value — secondary): surface **`derivatives()` OOB**
+   (L829/L831), **iso-curve OOB** (L1022/L1043) and the **`value(...,du,dv>0)`
+   "not implemented"** path (L1103); the base-class `Curve`/`Surface`
+   `derivatives` defaults (`bscurve.h` L121, `bssurf.h` L249–251) are only
+   reached by non-B-spline curve types outside this scope.
+
+### Tier 2 — interpolation
+
+9. **Interpolation argument guards** — `bscinterp.h` L98 (`build_3pt_tg_dir` < 3
+   pts), L301 (`interpolate(Q,p,mode)` p ≥ #pts), L356 (`interpolate(bound,
+   bound,cstr,p)` n < p+1). **[fixed]** `interpolation_argument_guards`.
+10. **Surface-interpolation guards** — `bssinterp.h` L303 (out-of-bounds
+    constraint), L308 (size not multiple of `n_polesv`). **[fixed]**
+    `surf_interpolation_argument_guards`. Still open: L315/L319 (mu/mv knot-shape
+    throws), L27/L111 (`extract_U` / direct `build_poles` size errors) — narrow
+    lower-level guards.
+11. Dense vs sparse threshold (`interp_sparse_threshold = 100`), banded vs
+    scattered, separable surface path — **already covered**
+    (`large_point_interpolation_banded`, `scattered_constr_points_sparse_path`,
+    `grid_interp_separable_matches_dense`). No gap.
+
+### Tier 3 — loft (feeds #40)
+
+12. **Loft input validation** — `bssbuild.h` L162 (< 2 curves), L254 (a curve not
+    touching the spine), L313 (U/V curves not intersecting). **[defer #40]** The
+    `< 2 curves` guard needs a spine `BSCurve`; the other two need geometric
+    near-miss inputs. Loft is being refactored in #40 (correctness → perf →
+    dedup); these validation tests are best written against the post-refactor
+    API rather than pinned to the current one now.
+
+## Tests added in this PR
+
+10 tests / 38 assertions, all on the priority perimeter, all fast (≤ 1 s each):
+
+- `tests_basisfunctions.cpp`: `eval_degree_0_and_1`,
+  `weight_projection_zero_weight_is_origin`, `find_span_out_of_domain_below`.
+- `tests_bscurve.cpp`: `ctor_rejects_unordered_and_wrong_size_knots`,
+  `eval_out_of_bounds_throws`, `pole_and_buffer_guards`.
+- `tests_bsinterp.cpp`: `interpolation_argument_guards`.
+- `tests_bssurf.cpp`: `ctor_rejects_invalid`, `eval_out_of_bounds_throws`,
+  `surf_interpolation_argument_guards`.
+
+No new **bugs** were found — every uncovered path is a correct guard or the
+deliberate high-degree fallback, so nothing is filed as a follow-up bug. The
+remaining open items above are either intentional (high-degree fallback),
+low-value secondary guards, or deferred to #40.

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Build and run gbs test targets.
+#
+# Usage:
+#   scripts/build_test.sh                      # build + run the default eval/interp test set
+#   scripts/build_test.sh tests_basisfunctions # build + run a single target
+#   scripts/build_test.sh t1 t2 t3             # build + run several targets
+#
+# Honours the existing (already-configured) build/ directory and the ninja
+# generator. Builds ONLY the requested test targets (no full re-link of the
+# slow Python bindings). Set DOCTEST_FILTER to pass a doctest -tc=<filter>.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build"
+
+# Default target set: the eval/interp coverage relevant to find_span (#42/#46).
+DEFAULT_TARGETS=(tests_basisfunctions tests_bscurve tests_surface_derivatives tests_surfaces)
+
+if [[ $# -gt 0 ]]; then
+    TARGETS=("$@")
+else
+    TARGETS=("${DEFAULT_TARGETS[@]}")
+fi
+
+echo ">> Building targets: ${TARGETS[*]}"
+ninja -C "${BUILD_DIR}" "${TARGETS[@]}"
+
+for t in "${TARGETS[@]}"; do
+    bin="${BUILD_DIR}/tests/${t}"
+    if [[ ! -x "${bin}" ]]; then
+        echo "!! No runnable binary at ${bin}, skipping run" >&2
+        continue
+    fi
+    echo ">> Running ${t}"
+    if [[ -n "${DOCTEST_FILTER:-}" ]]; then
+        "${bin}" -tc="${DOCTEST_FILTER}"
+    else
+        "${bin}"
+    fi
+done

--- a/scripts/cov_time.sh
+++ b/scripts/cov_time.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Diagnostic: time each priority coverage binary individually (pinned, perf
+# excluded) with a per-binary timeout, to spot tests that blow up under
+# instrumentation before committing to a full coverage run.
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-cov"
+EXCLUDE='*perf*,cpp_algo.par_vs_seq,tests_bscurve.curve_reparametrized'
+CAP="${1:-90}"
+TARGETS=(tests_basisfunctions tests_bscurve tests_bssurf tests_curve_derivatives
+         tests_surface_derivatives tests_curves tests_surfaces tests_bsinterp
+         tests_knotsfunctions tests_bssbuild tests_bsctools)
+for t in "${TARGETS[@]}"; do
+    bin="${BUILD_DIR}/tests/${t}"
+    start=$(date +%s)
+    timeout "${CAP}" taskset -c 0 env LLVM_PROFILE_FILE=/tmp/_covt.profraw \
+        "${bin}" -tce="${EXCLUDE}" >/dev/null 2>&1
+    rc=$?
+    end=$(date +%s)
+    printf '%-32s %3ds  rc=%s%s\n' "${t}" "$((end-start))" "${rc}" \
+        "$([[ ${rc} -eq 124 ]] && echo '  <-- TIMEOUT' || true)"
+done

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Reproduce the gbs test-coverage baseline (issue #50).
+#
+# Configures a DEDICATED build directory (build-cov/, never the main build/)
+# with clang + source-based coverage instrumentation, builds the priority
+# test targets, runs them and aggregates an llvm-cov report.
+#
+# Usage:
+#   scripts/coverage.sh             # configure (if needed) + build + report
+#   scripts/coverage.sh --report    # skip configure/build, just re-run + report
+#
+# Knobs (env):
+#   GBS_COV_BUILD_DIR  build dir (default: build-cov)
+#   CC / CXX           compiler (default: clang-21 / clang++-21)
+#
+# The matching `coverage` CMake target does the report step alone:
+#   cmake --build build-cov --target coverage
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${GBS_COV_BUILD_DIR:-${REPO_ROOT}/build-cov}"
+CC_BIN="${CC:-clang-21}"
+CXX_BIN="${CXX:-clang++-21}"
+
+# Priority-perimeter test executables (eval/span/basis, interp, loft).
+TARGETS=(
+    tests_basisfunctions
+    tests_bscurve
+    tests_bssurf
+    tests_curve_derivatives
+    tests_surface_derivatives
+    tests_curves
+    tests_surfaces
+    tests_bsinterp
+    tests_knotsfunctions
+    tests_bssbuild
+    tests_bsctools
+)
+
+MODE="${1:-full}"
+
+if [[ "${MODE}" != "--report" ]]; then
+    if [[ ! -f "${BUILD_DIR}/CMakeCache.txt" ]]; then
+        echo ">> configuring coverage build at ${BUILD_DIR}"
+        cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER="${CC_BIN}" \
+            -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
+            -DGBS_COVERAGE=ON \
+            -DGBS_USE_PYTHON_BINDINGS=OFF \
+            -DGBS_BUILD_STUBS=OFF
+    fi
+    echo ">> building priority test targets"
+    ninja -C "${BUILD_DIR}" "${TARGETS[@]}"
+fi
+
+"${REPO_ROOT}/scripts/coverage_report.sh" "${BUILD_DIR}" "${TARGETS[@]}"

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Run already-built, coverage-instrumented test binaries and aggregate a
+# source-based coverage report with llvm-cov.
+#
+# Usage:
+#   scripts/coverage_report.sh <build_dir> <test_exe> [<test_exe> ...]
+#
+# Produces, under <build_dir>/coverage/:
+#   - merged.profdata          (llvm-profdata merge of every run)
+#   - report.txt               (llvm-cov report, per-file region/line/branch %)
+#   - report_core.txt          (same, restricted to the priority perimeter)
+#   - uncovered_core.txt       (llvm-cov show, only-regions, priority headers)
+#
+# The llvm tooling is auto-selected to match the clang that built the binaries
+# (clang-21 -> llvm-profdata-21/llvm-cov-21); override with LLVM_PROFDATA /
+# LLVM_COV. Binaries are run from the repo root so their relative input paths
+# (tests/in/...) resolve.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: $0 <build_dir> <test_exe> [<test_exe> ...]" >&2
+    exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$1"; shift
+TESTS=("$@")
+
+# Skip micro-benchmarks: they only re-run already-covered eval paths millions of
+# times (10M curve evals, 100M-element std::transform timing). Under coverage
+# instrumentation they dominate wall-clock and add zero coverage. Override with
+# DOCTEST_EXCLUDE="" to run everything.
+# curve_reparametrized runs a full float arc-length integration (abs_curv over
+# ~1080 samples + reparametrized re-evaluation); under instrumentation it alone
+# takes minutes and only re-covers bsctools arc-length paths already hit cheaply
+# elsewhere. Excluded from the baseline (documented in bench/COVERAGE_AUDIT.md).
+DOCTEST_EXCLUDE="${DOCTEST_EXCLUDE-*perf*,cpp_algo.par_vs_seq,tests_bscurve.curve_reparametrized}"
+
+COV_DIR="${BUILD_DIR}/coverage"
+RAW_DIR="${COV_DIR}/raw"
+mkdir -p "${RAW_DIR}"
+rm -f "${RAW_DIR}"/*.profraw
+
+# Pick the llvm tools that match the compiler version, falling back to unversioned.
+detect_tool() {
+    local base="$1" override="$2"
+    if [[ -n "${override}" ]]; then echo "${override}"; return; fi
+    for cand in "${base}-21" "${base}-20" "${base}"; do
+        if command -v "${cand}" >/dev/null 2>&1; then echo "${cand}"; return; fi
+    done
+    echo "${base}"
+}
+PROFDATA="$(detect_tool llvm-profdata "${LLVM_PROFDATA:-}")"
+COV="$(detect_tool llvm-cov "${LLVM_COV:-}")"
+
+# Pin each run to a single core. The eval/interp paths use std::execution::par
+# (TBB backend); with coverage instrumentation the per-region profile counters
+# become cache-line-contended across all worker threads, so a parallel sweep
+# that takes milliseconds balloons to minutes of 60-core thrash. Coverage is
+# timing-independent, so serializing on one core gives identical coverage in a
+# fraction of the wall time. Disable with GBS_COV_PIN=0.
+PIN=()
+if [[ "${GBS_COV_PIN:-1}" != "0" ]] && command -v taskset >/dev/null 2>&1; then
+    PIN=(taskset -c 0)
+fi
+
+# Run each instrumented binary, one profraw per run. llvm-cov wants the FIRST
+# binary positional and the rest behind -object, otherwise it treats a trailing
+# positional source file as the main object ("not a valid object file").
+OBJECTS=()
+for t in "${TESTS[@]}"; do
+    bin="${BUILD_DIR}/tests/${t}"
+    if [[ ! -x "${bin}" ]]; then
+        echo "!! missing binary ${bin}, skipping" >&2
+        continue
+    fi
+    echo ">> running ${t}"
+    DT_ARGS=()
+    [[ -n "${DOCTEST_EXCLUDE}" ]] && DT_ARGS+=("-tce=${DOCTEST_EXCLUDE}")
+    ( cd "${REPO_ROOT}" && LLVM_PROFILE_FILE="${RAW_DIR}/${t}.profraw" "${PIN[@]}" "${bin}" "${DT_ARGS[@]}" >/dev/null )
+    if [[ ${#OBJECTS[@]} -eq 0 ]]; then
+        OBJECTS+=("${bin}")          # main object (positional)
+    else
+        OBJECTS+=(-object "${bin}")  # additional objects
+    fi
+done
+
+if [[ ${#OBJECTS[@]} -eq 0 ]]; then
+    echo "!! no instrumented binaries ran" >&2
+    exit 1
+fi
+
+echo ">> merging profiles with ${PROFDATA}"
+"${PROFDATA}" merge -sparse "${RAW_DIR}"/*.profraw -o "${COV_DIR}/merged.profdata"
+
+# Only attribute coverage to the library headers, never to test/3rd-party code.
+# llvm-cov has no "only this dir" flag, so drop everything else by regex.
+IGNORE_RE='(/micromamba/|/tests/|/testing/|/tests_3rdlibs/|/gbs-render/|/gbs-io/|/gbs-mesh/|/gbs-occt/|/gbs-cuda/|/Eigen/|/eigen|/usr/|/bench/)'
+# Priority perimeter: the headers whose coverage this audit ranks.
+CORE_FILES=(
+    "${REPO_ROOT}/gbs/basisfunctions.ixx"
+    "${REPO_ROOT}/gbs/bscurve.h"
+    "${REPO_ROOT}/gbs/bssurf.h"
+    "${REPO_ROOT}/gbs/bscinterp.h"
+    "${REPO_ROOT}/gbs/bssinterp.h"
+    "${REPO_ROOT}/gbs/knotsfunctions.ixx"
+    "${REPO_ROOT}/gbs/bssbuild.h"
+    "${REPO_ROOT}/gbs/bsctools.h"
+)
+
+echo ">> writing reports to ${COV_DIR}"
+"${COV}" report "${OBJECTS[@]}" -instr-profile="${COV_DIR}/merged.profdata" \
+    -show-branch-summary -ignore-filename-regex="${IGNORE_RE}" > "${COV_DIR}/report.txt"
+
+# Focused per-file view of the priority perimeter.
+"${COV}" report "${OBJECTS[@]}" -instr-profile="${COV_DIR}/merged.profdata" \
+    -show-branch-summary "${CORE_FILES[@]}" > "${COV_DIR}/report_core.txt"
+
+# Annotated source for the priority headers, regions + branch counts, so the
+# audit can point at the exact uncovered branches.
+"${COV}" show "${OBJECTS[@]}" -instr-profile="${COV_DIR}/merged.profdata" \
+    -show-branches=count -show-regions=true -show-line-counts=true \
+    "${CORE_FILES[@]}" > "${COV_DIR}/annotated_core.txt"
+
+echo
+echo "==== coverage (priority perimeter) ===="
+cat "${COV_DIR}/report_core.txt"
+echo
+echo "full report:    ${COV_DIR}/report.txt"
+echo "annotated core: ${COV_DIR}/annotated_core.txt"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,5 +41,34 @@ foreach(file_name ${SRC_LIST})
                 TARGETS ${test_exe_name}
                 MODULES ${VTK_LIBRARIES}
         )
-        
+
 endforeach()
+
+# Source-based coverage target (only meaningful when configured with
+# -DGBS_COVERAGE=ON). Runs the priority-perimeter test executables and
+# aggregates an llvm-cov report under ${CMAKE_BINARY_DIR}/coverage/.
+# Reproduce from scratch with scripts/coverage.sh.
+if(GBS_COVERAGE)
+        set(GBS_COVERAGE_TESTS
+                tests_basisfunctions
+                tests_bscurve
+                tests_bssurf
+                tests_curve_derivatives
+                tests_surface_derivatives
+                tests_curves
+                tests_surfaces
+                tests_bsinterp
+                tests_knotsfunctions
+                tests_bssbuild
+                tests_bsctools
+        )
+        add_custom_target(coverage
+                COMMAND ${CMAKE_COMMAND} -E env bash
+                        ${CMAKE_SOURCE_DIR}/scripts/coverage_report.sh
+                        ${CMAKE_BINARY_DIR} ${GBS_COVERAGE_TESTS}
+                DEPENDS ${GBS_COVERAGE_TESTS}
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                COMMENT "Running instrumented tests and aggregating llvm-cov report"
+                USES_TERMINAL
+        )
+endif()

--- a/tests/tests_basisfunctions.cpp
+++ b/tests/tests_basisfunctions.cpp
@@ -561,3 +561,78 @@ TEST(tests_basis_functions, eval_at_last_knot)
             }
     }
 }
+
+// ===========================================================================
+// Coverage edge cases (issue #50): low-degree evaluation, degenerate weight
+// and out-of-domain find_span. These exercise branches the baseline left
+// uncovered without going through the (exponential) pathological-degree path.
+// ===========================================================================
+
+// Degree 0 and degree 1 were never evaluated through the fast path: p == 0 is
+// a piecewise-constant (value == pole of the half-open span, derivative zero),
+// p == 1 is the control polyline (interpolates poles at knots, segment slope as
+// first derivative). Exercises basis_funcs/ders_basis_funs at their trivial
+// loop bounds.
+TEST(tests_basis_functions, eval_degree_0_and_1)
+{
+    using T = double;
+    using namespace gbs;
+
+    // ---- degree 0: 3 poles, knots {0,1,2,3}; C(u) == pole of its span -------
+    {
+        size_t p = 0;
+        std::vector<T> k = {0., 1., 2., 3.};
+        points_vector<T, 2> poles = {{0., 0.}, {1., 10.}, {2., 20.}};
+        ASSERT_LT(norm(eval_value_decasteljau<T, 2>(0.5, k, poles, p) - poles[0]), 1e-12);
+        ASSERT_LT(norm(eval_value_decasteljau<T, 2>(1.5, k, poles, p) - poles[1]), 1e-12);
+        ASSERT_LT(norm(eval_value_decasteljau<T, 2>(2.5, k, poles, p) - poles[2]), 1e-12);
+        // a derivative of a piecewise-constant (d > p) is identically zero
+        ASSERT_LT(norm(eval_value_decasteljau<T, 2>(1.5, k, poles, p, 1)), 1e-12);
+    }
+
+    // ---- degree 1: clamped linear, 3 poles; the control polyline -----------
+    {
+        size_t p = 1;
+        std::vector<T> k = {0., 0., 1., 2., 2.};
+        points_vector<T, 2> poles = {{0., 0.}, {1., 2.}, {2., 0.}};
+        BSCurve<T, 2> crv(poles, k, p);
+        ASSERT_LT(norm(crv.value(0.) - poles.front()), 1e-12);
+        ASSERT_LT(norm(crv.value(1.) - poles[1]), 1e-12);
+        ASSERT_LT(norm(crv.value(2.) - poles.back()), 1e-12);
+        // midpoint of the first segment is the average of its endpoints
+        ASSERT_LT(norm(crv.value(0.5) - point<T, 2>{0.5, 1.}), 1e-12);
+        // first derivative on [0,1) is the segment slope poles[1]-poles[0]
+        ASSERT_LT(norm(crv.value(0.5, 1) - point<T, 2>{1., 2.}), 1e-12);
+    }
+}
+
+// A homogeneous point with zero weight projects to the origin (degenerate
+// guard in weight_projection); a non-zero weight divides through.
+TEST(tests_basis_functions, weight_projection_zero_weight_is_origin)
+{
+    using T = double;
+    std::array<T, 4> hp0 = {3., 4., 5., 0.};
+    auto r0 = gbs::weight_projection(hp0); // -> std::array<T,3>
+    ASSERT_EQ(r0[0], 0.);
+    ASSERT_EQ(r0[1], 0.);
+    ASSERT_EQ(r0[2], 0.);
+
+    std::array<T, 4> hp = {3., 4., 5., 2.};
+    auto r = gbs::weight_projection(hp);
+    ASSERT_NEAR(r[0], 1.5, 1e-12);
+    ASSERT_NEAR(r[1], 2.0, 1e-12);
+    ASSERT_NEAR(r[2], 2.5, 1e-12);
+}
+
+// find_span on an out-of-domain parameter below the first knot must not loop
+// forever: the "no progress" break returns the lowest valid span p (the
+// closest one), instead of running off the knot vector.
+TEST(tests_basis_functions, find_span_out_of_domain_below)
+{
+    using T = double;
+    std::vector<T> k = {0., 0., 0., 1., 2., 3., 3., 3.};
+    size_t p = 2;
+    size_t n = k.size() - p - 1; // 5 poles, valid spans [2, 4]
+    size_t s = size_t(gbs::find_span(n, p, T(-1.0), k) - k.begin());
+    ASSERT_EQ(s, p);
+}

--- a/tests/tests_bscurve.cpp
+++ b/tests/tests_bscurve.cpp
@@ -363,3 +363,72 @@ TEST(tests_bscurve, eval_matches_recursive_basis_ground_truth)
         }
     }
 }
+
+// ===========================================================================
+// Coverage edge cases (issue #50): constructor validation, out-of-bounds
+// evaluation and the pole/knot mutation guards. Same family as #46/#48 — the
+// untested boundary checks that keep a malformed curve from being built or
+// evaluated past its domain.
+// ===========================================================================
+
+// check_curve rejects both an out-of-order knot vector and a size-inconsistent
+// (np, knots, p) triple — the two guards before the np >= p+1 check that
+// ctor_rejects_too_few_poles already pins.
+TEST(tests_bscurve, ctor_rejects_unordered_and_wrong_size_knots)
+{
+    using T = double;
+    std::vector<std::array<T, 3>> poles5 = {
+        {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {2., 1., 0.}, {2., 2., 0.}};
+
+    // Unordered interior knots (2 before 1): correct length, still invalid.
+    std::vector<T> k_unordered = {0., 0., 0., 2., 1., 3., 3., 3.};
+    ASSERT_EQ(poles5.size(), k_unordered.size() - 2 - 1);
+    ASSERT_THROW((gbs::BSCurve<T, 3>(poles5, k_unordered, 2)), std::invalid_argument);
+
+    // Size equation violated: p+1+np = 7 knots expected, 8 supplied.
+    std::vector<std::array<T, 3>> poles4 = {{0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {2., 1., 0.}};
+    std::vector<T> k_wrong_size = {0., 0., 0., 1., 2., 3., 3., 3.};
+    ASSERT_THROW((gbs::BSCurve<T, 3>(poles4, k_wrong_size, 2)), std::invalid_argument);
+}
+
+// Evaluation past the domain throws for value AND the one-pass derivatives, on
+// both the non-rational and rational curve. value() was the only path pinned
+// (eval_except); derivatives() and the rational overrides were uncovered.
+TEST(tests_bscurve, eval_out_of_bounds_throws)
+{
+    using T = double;
+    std::vector<T> k = {0., 0., 0., 1., 1., 1.};
+    std::vector<std::array<T, 2>> poles = {{0., 0.}, {1., 1.}, {2., 0.}};
+    const T oob = 2.0;
+
+    gbs::BSCurve<T, 2> crv(poles, k, 2);
+    std::array<std::array<T, 2>, 3> CK;
+    ASSERT_THROW(crv.derivatives(oob, 2, CK.data()), gbs::OutOfBoundsCurveEval<T>);
+
+    gbs::BSCurveRational<T, 2> rat(poles, k, 2);
+    ASSERT_THROW(rat.value(oob), gbs::OutOfBoundsCurveEval<T>);
+    ASSERT_THROW(rat.derivatives(oob, 2, CK.data()), gbs::OutOfBoundsCurveEval<T>);
+}
+
+// The pole accessor and the length-checked pole/knot mutators throw on a wrong
+// size, and changeBounds(k1, k2) re-parametrizes in place.
+TEST(tests_bscurve, pole_and_buffer_guards)
+{
+    using T = double;
+    std::vector<T> k = {0., 0., 0., 1., 1., 1.};
+    std::vector<std::array<T, 2>> poles = {{0., 0.}, {1., 1.}, {2., 0.}};
+    gbs::BSCurve<T, 2> crv(poles, k, 2);
+
+    ASSERT_THROW(crv.pole(99), std::out_of_range);
+
+    std::vector<std::array<T, 2>> too_many(4);
+    ASSERT_THROW(crv.copyPoles(too_many), std::length_error);
+    ASSERT_THROW(crv.movePoles(too_many), std::length_error);
+
+    std::vector<T> wrong_knots(5);
+    ASSERT_THROW(crv.copyKnots(wrong_knots), std::length_error);
+
+    crv.changeBounds(-1., 3.);
+    ASSERT_EQ(crv.bounds()[0], -1.);
+    ASSERT_EQ(crv.bounds()[1], 3.);
+}

--- a/tests/tests_bsinterp.cpp
+++ b/tests/tests_bsinterp.cpp
@@ -384,3 +384,38 @@ TEST(tests_bsinterp, scattered_constr_points_sparse_path)
     for (size_t i = 0; i < n; ++i)
         ASSERT_LT(gbs::distance(crv.value(u[i]), Q[i].v), 1e-9) << "i=" << i;
 }
+
+// ===========================================================================
+// Coverage edge cases (issue #50): the interpolation argument guards. These
+// reject malformed inputs before the solve, and were uncovered by the baseline.
+// ===========================================================================
+TEST(tests_bsinterp, interpolation_argument_guards)
+{
+    using T = double;
+    using gbs::point;
+
+    // build_3pt_tg_dir needs at least 3 points (Bessel 3-point tangents).
+    {
+        std::vector<std::array<T, 2>> pts = {{0., 0.}, {1., 0.}};
+        std::vector<T> u = {0., 1.};
+        ASSERT_THROW(gbs::build_3pt_tg_dir(pts, u), std::invalid_argument);
+    }
+
+    // interpolate(Q, p, mode): degree must be strictly below the point count.
+    {
+        std::vector<gbs::constrType<T, 2, 1>> Q = {
+            {point<T, 2>{0., 0.}}, {point<T, 2>{1., 1.}}, {point<T, 2>{2., 0.}}};
+        ASSERT_THROW((gbs::interpolate<T, 2>(Q, size_t{3}, gbs::KnotsCalcMode::CHORD_LENGTH)),
+                     std::domain_error);
+    }
+
+    // interpolate(begin, end, constraints, p): the number of constraints (here
+    // none, so n = 2 endpoints) must be >= p+1, else the system is rank-deficient.
+    {
+        gbs::bsc_bound<T, 2> pt_begin{0., point<T, 2>{0., 0.}};
+        gbs::bsc_bound<T, 2> pt_end{1., point<T, 2>{1., 1.}};
+        std::vector<gbs::bsc_constraint<T, 2>> no_cstr;
+        ASSERT_THROW(gbs::interpolate(pt_begin, pt_end, no_cstr, size_t{3}),
+                     std::invalid_argument);
+    }
+}

--- a/tests/tests_bssurf.cpp
+++ b/tests/tests_bssurf.cpp
@@ -736,3 +736,75 @@ TEST(tests_bssurf, grid_interp_separable_matches_dense)
             ASSERT_LT(gbs::norm(srf.value(u[iu], v[iv]) - Q[iu + nu * iv]), 1e-9)
                 << "u=" << u[iu] << " v=" << v[iv];
 }
+
+// ===========================================================================
+// Coverage edge cases (issue #50): surface constructor validation, out-of-
+// domain evaluation and the surface-interpolation argument guards.
+// ===========================================================================
+
+// The BSSurface constructor rejects an inconsistent pole count and an invalid
+// knot/degree combination in either parametric direction.
+TEST(tests_bssurf, ctor_rejects_invalid)
+{
+    using T = double;
+    std::vector<T> kU = {0., 0., 1., 1.}; // clamped degree 1 -> 2 poles
+    std::vector<T> kV = {0., 0., 1., 1.};
+    std::vector<std::array<T, 3>> poles4 = {{0., 0., 0.}, {1., 0., 0.}, {0., 1., 0.}, {1., 1., 0.}};
+
+    // Wrong pole count (need 2x2 = 4, give 3).
+    {
+        std::vector<std::array<T, 3>> poles3 = {{0., 0., 0.}, {1., 0., 0.}, {0., 1., 0.}};
+        ASSERT_THROW((gbs::BSSurface<T, 3>(poles3, kU, kV, 1, 1)), std::invalid_argument);
+    }
+    // Invalid U knots (out of order).
+    {
+        std::vector<T> kU_bad = {0., 0., 2., 1.};
+        ASSERT_THROW((gbs::BSSurface<T, 3>(poles4, kU_bad, kV, 1, 1)), std::invalid_argument);
+    }
+    // Invalid V knots (out of order).
+    {
+        std::vector<T> kV_bad = {0., 0., 2., 1.};
+        ASSERT_THROW((gbs::BSSurface<T, 3>(poles4, kU, kV_bad, 1, 1)), std::invalid_argument);
+    }
+}
+
+// Evaluating outside the U or V domain throws the matching directional error.
+TEST(tests_bssurf, eval_out_of_bounds_throws)
+{
+    using T = double;
+    std::vector<T> kU = {0., 0., 1., 1.};
+    std::vector<T> kV = {0., 0., 1., 1.};
+    std::vector<std::array<T, 3>> poles = {{0., 0., 0.}, {1., 0., 0.}, {0., 1., 0.}, {1., 1., 0.}};
+    gbs::BSSurface<T, 3> srf(poles, kU, kV, 1, 1);
+
+    ASSERT_THROW(srf.value(2.0, 0.5), gbs::OutOfBoundsSurfaceUEval<T>);
+    ASSERT_THROW(srf.value(0.5, 2.0), gbs::OutOfBoundsSurfaceVEval<T>);
+}
+
+// The constraint-based surface interpolation rejects constraints outside the
+// declared bounds and a constraint count that is not a multiple of n_polesv.
+TEST(tests_bssurf, surf_interpolation_argument_guards)
+{
+    using T = double;
+    auto cstr = [](T u, T v, const gbs::point<T, 3> &x, size_t du, size_t dv) {
+        return std::make_tuple(u, v, x, du, dv);
+    };
+
+    // Constraint at u = 2 lies outside the unit-square bounds.
+    {
+        std::vector<gbs::bss_constraint<T, 3>> Q = {
+            cstr(0.0, 0.0, {0., 0., 0.}, 0, 0),
+            cstr(2.0, 1.0, {1., 1., 0.}, 0, 0)};
+        ASSERT_THROW((gbs::interpolate(Q, size_t{2}, size_t{1}, size_t{1})),
+                     std::invalid_argument);
+    }
+    // 3 constraints is not a multiple of n_polesv = 2 (all within bounds).
+    {
+        std::vector<gbs::bss_constraint<T, 3>> Q = {
+            cstr(0.0, 0.0, {0., 0., 0.}, 0, 0),
+            cstr(1.0, 0.0, {1., 0., 0.}, 0, 0),
+            cstr(0.0, 1.0, {0., 1., 0.}, 0, 0)};
+        ASSERT_THROW((gbs::interpolate(Q, size_t{2}, size_t{1}, size_t{1})),
+                     std::length_error);
+    }
+}


### PR DESCRIPTION
## What

Establishes a reproducible **source-based coverage baseline** for the library
core and closes the cheap, real boundary gaps it surfaces. Safety net before the
loft refactor (#40); same family of edge cases that produced #46/#48.

Analysis + test-adding only — **no core algorithm logic is touched**, so this is
parallel-safe with the code PRs.

## Coverage infrastructure (off by default)

- `GBS_COVERAGE` CMake option — instruments **only the test executables**
  (`-fprofile-instr-generate -fcoverage-mapping`, on the `gbs_testing` target);
  a normal build is untouched. Requires Clang.
- `coverage` CMake target + `scripts/coverage.sh` — configures a dedicated
  `build-cov/` (clang-21), builds the eval/interp/loft test targets, runs them
  and aggregates with `llvm-cov`. `scripts/coverage_report.sh` does the
  run+merge+report stage; `scripts/cov_time.sh` is a per-binary timing check.

```sh
scripts/coverage.sh            # full: configure + build + run + report
cmake --build build-cov --target coverage   # report-only, in a configured tree
```

Two deliberate choices (documented in the audit): instrumented runs are **pinned
to one core** (the parallel evaluators' profile counters otherwise contend across
workers and turn ms sweeps into minutes — coverage is timing-independent, so this
is lossless), and **micro-benchmarks are excluded** (`*perf*`, the 100M-element
`par_vs_seq`, the arc-length `curve_reparametrized`).

## Baseline (priority perimeter)

| File | region | line | branch |
|------|-------:|-----:|-------:|
| `basisfunctions.ixx` | 81.0% | 88.2% | 76.1% |
| `bscurve.h` | 92.9% | 95.5% | 73.3% |
| `bssurf.h` | 88.0% | 91.2% | 70.5% |
| `bscinterp.h` | 97.7% | 93.1% | 95.5% |
| `bssinterp.h` | 86.2% | 86.0% | 74.3% |
| `knotsfunctions.ixx` | 90.6% | 93.7% | 83.1% |
| `bssbuild.h` | 95.8% | 97.2% | 89.3% |
| `bsctools.h` | 92.1% | 97.3% | 73.5% |
| **TOTAL** | **88.6%** | **93.0%** | **78.3%** |

Full ranked gap list + disposition in [`bench/COVERAGE_AUDIT.md`](bench/COVERAGE_AUDIT.md).

## Edge-case tests added (10 tests / 38 assertions, all fast)

- **eval/basis**: degree 0/1 evaluation, zero-weight projection → origin,
  `find_span` out-of-domain break.
- **curve**: `check_curve` unordered/wrong-size rejection, out-of-bounds
  value/derivatives (rational included), pole/knot mutation guards.
- **interp**: `build_3pt_tg_dir` / `interpolate` argument guards.
- **surface**: constructor validation, out-of-bounds eval, interpolation guards.

## Findings

No bugs found — every uncovered path is a correct guard or the **intentional
high-degree (p>24) recursive fallback** (exponential cost; testing it would
re-introduce a multi-minute test). Loft input-validation gaps are deferred to
#40 (best written against the post-refactor API).

Refs #50, epic #44.