### PR TITLE
fix(loft): rational flat_v overload returns a surface; unify degree clamp (#40 PR1)

### DIFF
--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -178,7 +178,7 @@ namespace gbs
         auto tg_i = get_tg_from_spine<T, dim, rational>(poles_v_lst,spine,bs_lst_cpy);
 
         // interpolate poles
-        size_t q = fmax(fmin(v_degree_max,n_poles_v-1),1); // degree V // diff
+        size_t q = std::max(std::min(v_degree_max, n_poles_v - 1), size_t{1}); // degree V, clamped to a valid range
         auto kv_flat = build_simple_mult_flat_knots<T>(v.front(),v.back(),n_poles_v * 2,q); //dif
         points_vector<T,dim + rational> poles;
         std::vector<constrType<T,dim + rational,2> > Q(n_poles_v); //diff

--- a/gbs/loft/loftGeneric.h
+++ b/gbs/loft/loftGeneric.h
@@ -25,10 +25,17 @@ namespace gbs{
     auto loft_generic(InputIt first, InputIt last, const std::vector<T> &v, const std::vector<T> &flat_v, size_t q)
     {
         auto curves_info = get_bs_curves_info<T, dim>(first, last);
+        // A degree-q loft needs at least q+1 sections; clamp so we never build a
+        // degenerate v-direction (consistent with the (…, v, q) overload). The
+        // clamped q must match the degree encoded in flat_v and is propagated to
+        // the surface ctor.
+        const size_t n_sections = curves_info.size();
+        if (n_sections > 0)
+            q = std::min(q, n_sections - 1);
         auto [poles, flat_u, p] = loft(curves_info, v, flat_v, q);
         using CurveType = typename std::iterator_traits<InputIt>::value_type;
         if constexpr (std::is_same_v<CurveType, BSCurveRational<T, dim>>) {
-            return BSCurveRational<T, dim>(poles, flat_u, flat_v, p, q);
+            return BSSurfaceRational<T, dim>(poles, flat_u, flat_v, p, q);
         } else {
             return BSSurface<T, dim>(poles, flat_u, flat_v, p, q);
         }
@@ -50,7 +57,7 @@ namespace gbs{
      * @param flat_v A flattened knot vector in the 'v' direction for the lofted surface.
      * @param q The degree of the lofted surface in the 'v' direction.
      * @return A lofted surface represented in a suitable format. The type of the returned object depends on whether
-     *         the input curves are rational or non-rational. If the curves are rational, a `BSCurveRational` object
+     *         the input curves are rational or non-rational. If the curves are rational, a `BSSurfaceRational` object
      *         is returned; otherwise, a `BSSurface` object is returned.
      */
     template <typename T, size_t dim, typename Container>

--- a/tests/tests_bssbuild.cpp
+++ b/tests/tests_bssbuild.cpp
@@ -747,3 +747,117 @@ TEST(tests_bssbuild, loft2)
         gbs::plot(gbs::make_actor(srf_, { 51./255.,  161./255.,  201./255.}, 500, 500), c1, c2, c3);
 
 }
+
+// Locks the latent return-type bug (#40 PR1, finding #1): lofting RATIONAL
+// curves through the flat_v overload must yield a BSSurfaceRational (a surface),
+// not a curve. Before the fix this overload returned a BSCurveRational and did
+// not even compile for rational input (no matching ctor) — so merely
+// instantiating it here already guards the regression; the static_assert and
+// interpolation check make the intent explicit.
+TEST(tests_bssbuild, loft_rational_flat_v_returns_surface)
+{
+    using T = double;
+    constexpr size_t dim = 3;
+    size_t p = 2;
+    std::vector<T> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
+    gbs::points_vector_4d_d poles1 =
+    {
+        {0.,0.,0.,1.}, {0.,1.,0.,1.1}, {1.,1.,0.,1.}, {1.,1.,0.0,1.},
+        {2.,1.,0.0,1.}, {3.,1.,0.,1.1}, {0.,4.,0.,1.},
+    };
+    gbs::points_vector_4d_d poles2 =
+    {
+        {0.,0.,1.,1.}, {0.,1.,1.3,1.}, {1.,1.,1.2,1.}, {1.,2.,1.4,1.},
+        {2.,1.,1.3,1.2}, {3.,1.,1.1,1.}, {2.,4.,1.,1.},
+    };
+    gbs::points_vector_4d_d poles3 =
+    {
+        {0.,0.,2.,1.}, {0.,1.,2.2,1.}, {1.,1.,2.2,1.2}, {1.,2.,2.3,1.},
+        {2.,1.,2.1,1.}, {3.,1.,2.,1.}, {1.,4.,2.,1.},
+    };
+    gbs::BSCurveRational3d_d c1(poles1,k,p);
+    gbs::BSCurveRational3d_d c2(poles2,k,p);
+    gbs::BSCurveRational3d_d c3(poles3,k,p);
+
+    std::vector<gbs::BSCurveRational<T,dim>> bs_lst{c1,c2,c3};
+    std::vector<T> v{0., 0.5, 1.0};
+    size_t q = 2; // n_sections - 1
+    auto flat_v = gbs::build_simple_mult_flat_knots(v, q);
+
+    auto s = gbs::loft_generic<T,dim>(bs_lst.begin(), bs_lst.end(), v, flat_v, q);
+
+    // The whole point of finding #1: this is a SURFACE, not a curve.
+    static_assert(std::is_same_v<decltype(s), gbs::BSSurfaceRational<T,dim>>,
+                  "rational loft via the flat_v overload must return a BSSurfaceRational");
+
+    // ... and it must actually interpolate the input sections in v.
+    auto [u1,u2] = c1.bounds();
+    const gbs::BSCurveRational3d_d* sections[] = {&c1,&c2,&c3};
+    for(size_t j{}; j<3; ++j)
+    {
+        CAPTURE(j);
+        for(T u : gbs::make_range(u1,u2,50))
+        {
+            CAPTURE(u);
+            ASSERT_LT(gbs::distance(s(u, v[j]), (*sections[j])(u)), 1e-6);
+        }
+    }
+}
+
+// All loft entry points must handle an over-specified degree IDENTICALLY:
+// clamp q to (n_sections - 1) instead of throwing (#40 PR1, findings #2/#7).
+TEST(tests_bssbuild, loft_overspecified_degree_clamps_consistently)
+{
+    using T = double;
+    constexpr size_t dim = 3;
+    size_t p = 2;
+    std::vector<T> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
+    auto make_section = [&](T z){
+        gbs::points_vector_3d_d poles = {
+            {0.,0.,z},{0.,1.,z},{1.,1.,z},{1.,1.,z},{2.,1.,z},{3.,1.,z},{0.,4.,z}
+        };
+        return gbs::BSCurve<T,dim>(poles, k, p);
+    };
+    auto c1 = make_section(0.), c2 = make_section(1.), c3 = make_section(2.);
+    std::vector<gbs::BSCurve<T,dim>> bs_lst{c1,c2,c3};
+    std::vector<T> v{0., 0.5, 1.0};
+
+    const size_t n_sections = bs_lst.size();
+    const size_t q_over    = 7;                 // way above n_sections - 1 == 2
+    const size_t q_clamped = n_sections - 1;    // expected degree at every entry point
+
+    // Reference path: (…, v, q) overload (already clamped since #36).
+    auto s_ref = gbs::loft(bs_lst, v, q_over);
+    ASSERT_EQ(s_ref.degreeV(), q_clamped);
+
+    // q_max path.
+    auto s_qmax = gbs::loft(bs_lst, q_over);
+    ASSERT_EQ(s_qmax.degreeV(), q_clamped);
+
+    // flat_v overload: a sane caller builds flat_v for the clamped degree; the
+    // over-specified q must clamp to the same value (not throw) and yield the
+    // SAME surface as the reference path.
+    auto flat_v = gbs::build_simple_mult_flat_knots(v, q_clamped);
+    auto s_flat = gbs::loft_generic<T,dim>(bs_lst.begin(), bs_lst.end(), v, flat_v, q_over);
+    ASSERT_EQ(s_flat.degreeV(), q_clamped);
+    ASSERT_EQ(s_flat.degreeU(), s_ref.degreeU());
+
+    auto [u1,u2] = c1.bounds();
+    for(T vv : gbs::make_range(0.,1.,11))
+    {
+        CAPTURE(vv);
+        for(T u : gbs::make_range(u1,u2,50))
+        {
+            CAPTURE(u);
+            ASSERT_LT(gbs::distance(s_flat(u,vv), s_ref(u,vv)), 1e-9);
+        }
+    }
+
+    // Spine loft: an over-specified v_degree_max must clamp the same way.
+    gbs::BSCurve<T,dim> spine(
+        gbs::points_vector_3d_d{{0.5,1.,0.},{0.5,1.,1.},{0.5,1.,2.}},
+        std::vector<T>{0.,0.,0.,1.,1.,1.}, size_t{2});
+    std::list<gbs::BSCurve<T,dim>> spine_lst{c1,c2,c3};
+    auto s_spine = gbs::loft(spine_lst, spine, q_over);
+    ASSERT_EQ(s_spine.degreeV(), q_clamped);
+}


### PR DESCRIPTION
## loft PR1 — correctness (part 1/3 of #40)

This is **PR1 (correctness) only** of the loft audit #40. PR2 (perf — hoist the
spine factorization, batch `build_loft_surface_poles`) and PR3 (dedup the ~20
overloads / consolidate the two implementations) remain to be done as separate,
serial PRs on the same files.

### Changes

1. **Latent wrong return type (finding #1).** `loft_generic(first, last, v, flat_v, q)`
   returned a `BSCurveRational` (a *curve*) for rational input instead of a
   `BSSurfaceRational`. Dormant — no test exercised it — but it would have been a
   hard compile error the moment it was used with rational curves (no matching
   `BSCurveRational(poles, flat_u, flat_v, p, q)` ctor). Aligned with the sibling
   `(…, v, q)` overload.

2. **Inconsistent degree clamp (finding #2).** `q = std::min(q, n_sections-1)`
   existed only in the `(…, v, q)` overload (added in #36). Applied the same clamp
   in the `(…, v, flat_v, q)` overload and propagated the clamped `q` to the
   surface ctor, so an over-specified degree clamps consistently everywhere
   instead of throwing via the hardened `check_curve`. The spine loft
   (`bssbuild.h`) already clamps to `n_poles_v-1`.

3. **`fmax/fmin` on `size_t` (finding #7).** Replaced the floating-point
   `fmax(fmin(...))` in the spine-loft degree computation with integer
   `std::max`/`std::min`.

### Tests (added to `tests/tests_bssbuild.cpp`)

- `loft_rational_flat_v_returns_surface` — lofts **rational** curves through the
  `flat_v` overload, `static_assert`s the result is a `BSSurfaceRational`, and
  checks it interpolates the input sections. Locks finding #1 (it would not have
  compiled before the fix).
- `loft_overspecified_degree_clamps_consistently` — an over-specified `q` clamps
  to `n_sections-1` **identically** across the `(…, v, q)`, `q_max`, `flat_v` and
  spine entry points (all clamp, none throw); the `flat_v` path is verified to
  produce the same surface as the reference `(…, v, q)` path.

### Acceptance

- Rational loft via the `flat_v` overload returns a `BSSurfaceRational` (no curve). ✅
- Degree handling is identical across all loft entry points. ✅
- No behavioural change for existing loft tests — `tests_bssbuild` green:
  **15/15 cases, 2627/2627 assertions passed**. ✅

Out of scope here (tracked in #40): PR2 perf (spine factorization hoist,
`build_loft_surface_poles` batching) and PR3 overload/implementation dedup.

Refs #40 (PR1) · epic #44
