### PR TITLE
perf(loft): hoist spine v-system factorization, batch pole solves (#40 PR2)

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -27,3 +27,7 @@ target_link_libraries(bench_eval_compare PRIVATE Eigen3::Eigen)
 add_executable(bench_interp bench_interp.cpp)
 target_include_directories(bench_interp PRIVATE ${GBS_ROOT} ${GBS_ROOT}/inc)
 target_link_libraries(bench_interp PRIVATE Eigen3::Eigen)
+
+add_executable(bench_loft bench_loft.cpp)
+target_include_directories(bench_loft PRIVATE ${GBS_ROOT} ${GBS_ROOT}/inc)
+target_link_libraries(bench_loft PRIVATE Eigen3::Eigen)

--- a/bench/bench_loft.cpp
+++ b/bench/bench_loft.cpp
@@ -1,0 +1,140 @@
+// Performance audit harness for the spine-loft pole solve (issue #40 PR2 / #44).
+//
+// The spine loft interpolates, for every u-pole column, a v-direction constraint
+// system (position + spine tangent). The v-collocation matrix is IDENTICAL for
+// every column, yet the old code called the single-column build_poles() inside
+// the loop over u-poles, so that matrix was assembled and factorized n_poles_u
+// times. PR2 adds a batched build_poles() that assembles + factorizes ONCE and
+// solves every column as multiple right-hand sides.
+//
+// This bench isolates exactly that kernel: it builds the same constraint columns
+// the spine loft feeds to build_poles, then times
+//   OLD: a loop of single-column build_poles()  (re-factorize per column)
+//   NEW: one batched build_poles(Q_cols, ...)    (factorize once)
+// and prints the speedup. Both overloads are exercised against the same data, so
+// the comparison is self-contained (no baseline checkout needed) and the poles
+// are verified identical to machine precision.
+//
+// We sweep:
+//   - n_poles_u  (columns sharing one factorization) -> redundant factorizations
+//   - n_poles_v  (sections) -> size of the v-collocation matrix
+
+#include <gbs/bscinterp.h>
+#include <gbs/bsctools.h>
+
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using clk = std::chrono::steady_clock;
+volatile double sink = 0.0;
+
+template <typename F>
+double best_ms(int reps, F &&f)
+{
+    double best = 1e300;
+    for (int r = 0; r < reps; ++r)
+    {
+        auto t0 = clk::now();
+        f();
+        auto t1 = clk::now();
+        best = std::min(best, std::chrono::duration<double, std::milli>(t1 - t0).count());
+    }
+    return best;
+}
+
+// Build the (position + tangent) constraint columns and the v-system exactly as
+// the spine loft does: n_poles_u columns, each with n_poles_v position+tangent
+// constraints, sharing one degree-q v-collocation matrix.
+struct loft_solve_input
+{
+    std::vector<std::vector<gbs::constrType<double, 3, 2>>> Q_cols;
+    std::vector<double> kv_flat;
+    std::vector<double> v;
+    size_t q;
+};
+
+static loft_solve_input make_input(size_t n_poles_u, size_t n_poles_v)
+{
+    loft_solve_input in;
+    in.q = std::max<size_t>(std::min<size_t>(3, n_poles_v - 1), 1);
+    in.v.resize(n_poles_v);
+    for (size_t j = 0; j < n_poles_v; ++j)
+        in.v[j] = double(j) / double(n_poles_v - 1);
+    in.kv_flat = gbs::build_simple_mult_flat_knots<double>(in.v.front(), in.v.back(), n_poles_v * 2, in.q);
+
+    in.Q_cols.resize(n_poles_u, std::vector<gbs::constrType<double, 3, 2>>(n_poles_v));
+    for (size_t i = 0; i < n_poles_u; ++i)
+        for (size_t j = 0; j < n_poles_v; ++j)
+        {
+            double u = double(i) / double(n_poles_u - 1);
+            double t = double(j) / double(n_poles_v - 1);
+            std::array<double, 3> pos = {std::cos(3.0 * u) + t, std::sin(3.0 * u), 2.0 * t};
+            std::array<double, 3> tg = {0.1, 0.2, 2.0};
+            in.Q_cols[i][j] = gbs::constrType<double, 3, 2>{pos, tg};
+        }
+    return in;
+}
+
+// OLD path: re-factorize the v-system per column.
+static std::vector<std::array<double, 3>> solve_per_column(const loft_solve_input &in)
+{
+    std::vector<std::array<double, 3>> poles;
+    for (const auto &Q : in.Q_cols)
+    {
+        auto poles_v = gbs::build_poles(Q, in.kv_flat, in.v, in.q);
+        poles.insert(poles.end(), poles_v.begin(), poles_v.end());
+    }
+    return poles;
+}
+
+// NEW path: factorize once, solve all columns as multiple RHS.
+static std::vector<std::array<double, 3>> solve_batched(const loft_solve_input &in)
+{
+    return gbs::build_poles(in.Q_cols, in.kv_flat, in.v, in.q);
+}
+
+static double max_diff(const std::vector<std::array<double, 3>> &a,
+                       const std::vector<std::array<double, 3>> &b)
+{
+    double m = 0.0;
+    for (size_t i = 0; i < a.size(); ++i)
+        for (size_t d = 0; d < 3; ++d)
+            m = std::max(m, std::abs(a[i][d] - b[i][d]));
+    return m;
+}
+
+int main()
+{
+    std::printf("SPINE-loft pole solve: per-column re-factorize vs batched factorize-once\n\n");
+
+    std::printf("3 sections (6x6 v-system), vs n_poles_u (columns)\n");
+    std::printf("%-12s %12s %12s %10s %12s\n", "n_poles_u", "old ms", "new ms", "speedup", "max diff");
+    std::printf("-----------------------------------------------------------------\n");
+    for (size_t nu : {32u, 64u, 128u, 256u, 512u})
+    {
+        auto in = make_input(nu, 3);
+        int reps = nu <= 128 ? 9 : 5;
+        double old_ms = best_ms(reps, [&] { sink += solve_per_column(in)[0][0]; });
+        double new_ms = best_ms(reps, [&] { sink += solve_batched(in)[0][0]; });
+        double diff = max_diff(solve_per_column(in), solve_batched(in));
+        std::printf("%-12zu %12.3f %12.3f %9.2fx %12.2e\n", nu, old_ms, new_ms, old_ms / new_ms, diff);
+    }
+
+    std::printf("\n256 columns, vs n_poles_v (v-system size = 2*n_poles_v)\n");
+    std::printf("%-12s %12s %12s %10s %12s\n", "n_poles_v", "old ms", "new ms", "speedup", "max diff");
+    std::printf("-----------------------------------------------------------------\n");
+    for (size_t nv : {3u, 5u, 9u, 17u, 33u})
+    {
+        auto in = make_input(256, nv);
+        double old_ms = best_ms(5, [&] { sink += solve_per_column(in)[0][0]; });
+        double new_ms = best_ms(5, [&] { sink += solve_batched(in)[0][0]; });
+        double diff = max_diff(solve_per_column(in), solve_batched(in));
+        std::printf("%-12zu %12.3f %12.3f %9.2fx %12.2e\n", nv, old_ms, new_ms, old_ms / new_ms, diff);
+    }
+
+    std::printf("[sink=%g]\n", sink);
+    return 0;
+}

--- a/gbs/bscinterp.h
+++ b/gbs/bscinterp.h
@@ -171,6 +171,57 @@ template <typename T,size_t dim,size_t nc>
     return poles;
 }
 
+// Batched, constrained pole solve. Every column in `Q_cols` is interpolated
+// through the SAME (k_flat, u, deg) constraint system, so the banded collocation
+// matrix is assembled and factorized ONCE and every column is solved together as
+// extra right-hand sides. Equivalent to calling the single-column overload above
+// once per column, but without re-building/re-factorizing the matrix each time
+// (the lone real perf win of the spine loft, issue #40 PR2 / #44).
+//
+// The returned poles are the per-column results concatenated in order: column 0's
+// `n_pt*nc` poles, then column 1's, ... — matching repeated single-column calls.
+template <typename T, size_t dim, size_t nc>
+auto build_poles(const std::vector<std::vector<constrType<T, dim, nc>>> &Q_cols,
+                 const std::vector<T> &k_flat, const std::vector<T> &u, size_t deg)
+    -> std::vector<std::array<T, dim>>
+{
+    if (Q_cols.empty())
+        return {};
+
+    const size_t n_cols = Q_cols.size();
+    const size_t n_pt = Q_cols.front().size();
+    const auto n_poles = Eigen::Index(n_pt * nc);
+
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_poles, n_poles);
+    build_poles_matrix<T, nc>(k_flat, u, deg, n_poles, N);
+
+    // Same banded sparse LU (natural ordering) as the single-column overload; it
+    // is factorized once and reused across every column AND spatial component.
+    Eigen::SparseMatrix<T> Ns = N.sparseView();
+    Ns.makeCompressed();
+    Eigen::SparseLU<Eigen::SparseMatrix<T>, Eigen::NaturalOrdering<int>> solver;
+    solver.analyzePattern(Ns);
+    solver.factorize(Ns);
+
+    // One right-hand side per (column, spatial component).
+    MatrixX<T> B(n_poles, Eigen::Index(n_cols * dim));
+    for (size_t c = 0; c < n_cols; ++c)
+        for (size_t i = 0; i < n_pt; ++i)
+            for (size_t deriv = 0; deriv < nc; ++deriv)
+                for (size_t d = 0; d < dim; ++d)
+                    B(Eigen::Index(nc * i + deriv), Eigen::Index(c * dim + d)) = Q_cols[c][i][deriv][d];
+
+    MatrixX<T> X = solver.solve(B);
+
+    std::vector<std::array<T, dim>> poles(size_t(n_poles) * n_cols);
+    for (size_t c = 0; c < n_cols; ++c)
+        for (Eigen::Index i = 0; i < n_poles; ++i)
+            for (size_t d = 0; d < dim; ++d)
+                poles[c * size_t(n_poles) + size_t(i)][d] = X(i, Eigen::Index(c * dim + d));
+
+    return poles;
+}
+
 template <typename T, size_t dim>
 auto build_poles(const std::vector<constrPoint<T, dim>> &Q, const std::vector<T> &k_flat, size_t deg) -> std::vector<std::array<T, dim>>
 {

--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -183,6 +183,13 @@ namespace gbs
         points_vector<T,dim + rational> poles;
         std::vector<constrType<T,dim + rational,2> > Q(n_poles_v); //diff
 
+        // Build one constraint column (position + spine tangent) per u-pole. The
+        // v-collocation system is identical for every column, so collect them and
+        // hand them to the batched build_poles, which factorizes the matrix ONCE
+        // and solves all columns as multiple RHS instead of re-factorizing per
+        // column (issue #40 PR2 / #44).
+        std::vector<std::vector<constrType<T, dim + rational, 2>>> Q_cols;
+        Q_cols.reserve(n_poles_u);
         auto pt_and_tg_i = boost::combine(poles_v_lst,tg_i);
         for (auto pt_and_tg : pt_and_tg_i)
         {
@@ -196,9 +203,9 @@ namespace gbs
                 [&](const auto &pt_,const auto &tg_) {
                     return constrType<T, dim + rational, 2>{pt_, tg_};
                 });
-            auto poles_v = build_poles(Q, kv_flat, v, q);
-            poles.insert(poles.end(), poles_v.begin(), poles_v.end());
+            Q_cols.push_back(Q);
         }
+        poles = build_poles(Q_cols, kv_flat, v, q);
 
         // build surf
         using bss_type = typename std::conditional<rational,BSSurfaceRational<T, dim>,BSSurface<T, dim>>::type;

--- a/gbs/loft/loftBase.h
+++ b/gbs/loft/loftBase.h
@@ -21,7 +21,6 @@ namespace gbs{
                             const std::vector<T> &flat_v, const std::vector<T> &v, const std::vector<T> &flat_u, size_t p,
                             size_t q)
     {
-        auto poles_curves_t = transpose_poles(poles_curves);
         size_t ncr = poles_curves.size();
         size_t nu = poles_curves[0].size();
         size_t nv = poles_curves.size();
@@ -30,27 +29,28 @@ namespace gbs{
         build_poles_matrix<T, 1>(flat_v, v, q, ncr, N);
         auto N_inv = N.partialPivLu();
 
-        std::vector<std::vector<std::array<T, dim>>> poles_t(nu, std::vector<std::array<T, dim>>(nv));
-
+        // Assemble every right-hand side at once (one column per (u-index, dim))
+        // and solve them in a single batched back-substitution, reusing the single
+        // factorization above instead of one solve() per (i, d). The RHS is read
+        // straight from poles_curves[j][i][d] — no transpose copy — and the result
+        // is written directly into the flattened, v-outer/u-inner pole layout that
+        // the surface ctor expects, avoiding the former double transpose_poles +
+        // flatten_poles round trip (issue #40 PR2 / #44).
+        MatrixX<T> B(nv, Eigen::Index(nu * dim));
         for (size_t i = 0; i < nu; ++i)
-        {
             for (size_t d = 0; d < dim; ++d)
-            {
-                VectorX<T> b(nv);
-                std::transform(poles_curves_t[i].begin(), poles_curves_t[i].end(), b.begin(),
-                            [d](const auto &arr)
-                            { return arr[d]; });
-
-                auto x = N_inv.solve(b);
-
                 for (size_t j = 0; j < nv; ++j)
-                {
-                    poles_t[i][j][d] = x(j);
-                }
-            }
-        }
+                    B(Eigen::Index(j), Eigen::Index(i * dim + d)) = poles_curves[j][i][d];
 
-        return flatten_poles(transpose_poles(poles_t));
+        MatrixX<T> X = N_inv.solve(B);
+
+        std::vector<std::array<T, dim>> poles(nu * nv);
+        for (size_t j = 0; j < nv; ++j)
+            for (size_t i = 0; i < nu; ++i)
+                for (size_t d = 0; d < dim; ++d)
+                    poles[j * nu + i][d] = X(Eigen::Index(j), Eigen::Index(i * dim + d));
+
+        return poles;
     }
 
     /**

--- a/scripts/build_bench.sh
+++ b/scripts/build_bench.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Configure + build the standalone bench/ project (Release) and run a bench.
+#
+# Usage:
+#   scripts/build_bench.sh                 # build all bench targets
+#   scripts/build_bench.sh bench_loft      # build + run a single bench
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/bench/build"
+
+cmake -S "${REPO_ROOT}/bench" -B "${BUILD_DIR}" -G Ninja -DCMAKE_BUILD_TYPE=Release >/dev/null
+
+if [[ $# -gt 0 ]]; then
+    ninja -C "${BUILD_DIR}" "$@"
+    for t in "$@"; do
+        bin="${BUILD_DIR}/${t}"
+        if [[ -x "${bin}" ]]; then
+            echo ">> Running ${t}"
+            "${bin}"
+        fi
+    done
+else
+    ninja -C "${BUILD_DIR}"
+fi


### PR DESCRIPTION
## What

#40 **PR2 (perf)** — the spine-loft performance hotspot. Correctness (PR1, #52) is merged; the ~20-overload dedup (PR3) is intentionally **not** in here (same files, so it lands after this).

### Changes
- **`bscinterp.h`** — new batched `build_poles` overload: assembles + factorizes the banded sparse v-collocation matrix **once** and solves every column as multiple right-hand sides. Equivalent to repeated single-column calls, without re-factorizing per column.
- **`bssbuild.h`** (spine loft) — was calling the single-column `build_poles` *inside* the loop over u-poles, so the identical v-system was re-assembled and re-factorized `n_poles_u` times. Now collects the constraint columns and issues one batched call. *(audit finding #3)*
- **`loftBase.h`** (`build_loft_surface_poles`) — solve all `(u-index, dim)` RHS in a single batched back-substitution reusing the one `partialPivLu` factorization (was one `solve()` per `(i, d)`); read the RHS straight from `poles_curves` and write directly into the flattened v-outer/u-inner layout — dropping the in-loop `VectorX b` allocation and the double `transpose_poles` + `flatten_poles` round trip. *(audit finding #4)*
- **`bench/bench_loft.cpp`** (+ CMake, `scripts/build_bench.sh`) — mirrors `bench/bench_interp.cpp`; contrasts the old per-column re-factorize against the batched factorize-once kernel.

## Behaviour unchanged
- All `tests_bssbuild` loft cases pass (15 cases / 2627 assertions).
- Poles verified identical to the pre-PR2 implementation on both refactored paths: **max abs diff ~4e-16**, well within the 1e-9 acceptance.

## Measured gain (`bench_loft`, isolated v-system pole solve)

3 sections (6×6 v-system), vs `n_poles_u` (columns):

| n_poles_u | old ms | new ms | speedup |
|-----------|--------|--------|---------|
| 32  | 0.239 | 0.018 | 13.4× |
| 128 | 0.792 | 0.052 | 15.1× |
| 512 | 1.741 | 0.140 | 12.4× |

256 columns, vs `n_poles_v` (v-system size = 2·n_poles_v):

| n_poles_v | old ms | new ms | speedup |
|-----------|--------|--------|---------|
| 3  | 0.879 | 0.054 | 16.3× |
| 17 | 3.404 | 0.384 | 8.9× |
| 33 | 6.693 | 0.801 | 8.4× |

The spine loft factorizes the v-system **once**, not per column.

## Acceptance (#40)
- [x] Spine loft factorizes the v-system once, not per column.
- [x] No behavioural change for existing loft tests.
- [x] Poles identical to before (≤ 1e-9; measured ~4e-16).
- [x] Small bench mirroring `bench_interp`.

Refs #40 (PR2), epic #44. **PR3 (dedup)** still to do — it touches the same files, so it follows once this merges.
