### PR TITLE
refactor(loft): dedup overloads + one shared pole-solve core (PR3, closes #40)

### DIFF
--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -178,38 +178,29 @@ namespace gbs
         auto tg_i = get_tg_from_spine<T, dim, rational>(poles_v_lst,spine,bs_lst_cpy);
 
         // interpolate poles
+        constexpr size_t dim_t = dim + rational;
         size_t q = std::max(std::min(v_degree_max, n_poles_v - 1), size_t{1}); // degree V, clamped to a valid range
         auto kv_flat = build_simple_mult_flat_knots<T>(v.front(),v.back(),n_poles_v * 2,q); //dif
-        points_vector<T,dim + rational> poles;
-        std::vector<constrType<T,dim + rational,2> > Q(n_poles_v); //diff
 
-        // Build one constraint column (position + spine tangent) per u-pole. The
-        // v-collocation system is identical for every column, so collect them and
-        // hand them to the batched build_poles, which factorizes the matrix ONCE
-        // and solves all columns as multiple RHS instead of re-factorizing per
-        // column (issue #40 PR2 / #44).
-        std::vector<std::vector<constrType<T, dim + rational, 2>>> Q_cols;
-        Q_cols.reserve(n_poles_u);
-        auto pt_and_tg_i = boost::combine(poles_v_lst,tg_i);
-        for (auto pt_and_tg : pt_and_tg_i)
-        {
-            auto [pt, tg] = pt_and_tg;
-            std::transform(
-                // std::execution::par, // not working with boost::combine
-                pt.begin(),
-                pt.end(),
-                tg.begin(),
-                Q.begin(),
-                [&](const auto &pt_,const auto &tg_) {
-                    return constrType<T, dim + rational, 2>{pt_, tg_};
-                });
-            Q_cols.push_back(Q);
-        }
-        poles = build_poles(Q_cols, kv_flat, v, q);
+        // One constraint column per u-pole: at each section, position + spine
+        // tangent (nc == 2). Assemble them straight into the shared loft core's RHS
+        // (rows = 2*n_poles_v v-DOFs, cols = n_poles_u*dim_t) and let it factorize
+        // the v-system ONCE, batch-solve every column, and emit poles already in
+        // the surface layout — the same core the plain loft uses, so spine and
+        // non-spine no longer carry parallel pole builders (issue #40 PR2/PR3 / #44).
+        MatrixX<T> B(Eigen::Index(2 * n_poles_v), Eigen::Index(n_poles_u * dim_t));
+        for (size_t i = 0; i < n_poles_u; ++i)
+            for (size_t j = 0; j < n_poles_v; ++j)
+                for (size_t d = 0; d < dim_t; ++d)
+                {
+                    B(Eigen::Index(2 * j + 0), Eigen::Index(i * dim_t + d)) = poles_v_lst[i][j][d];
+                    B(Eigen::Index(2 * j + 1), Eigen::Index(i * dim_t + d)) = tg_i[i][j][d];
+                }
+        auto poles = build_loft_surface_poles_core<T, dim_t, 2>(B, kv_flat, v, q);
 
         // build surf
         using bss_type = typename std::conditional<rational,BSSurfaceRational<T, dim>,BSSurface<T, dim>>::type;
-        return bss_type( inverted_uv_poles(poles,n_poles_u),  ku_flat, kv_flat, p , q );
+        return bss_type( poles,  ku_flat, kv_flat, p , q );
     }
 
     template <typename T, size_t dim>

--- a/gbs/loft/loftBase.h
+++ b/gbs/loft/loftBase.h
@@ -6,13 +6,54 @@
 namespace gbs{
 
     /**
-     * Builds the poles for a loft surface from a set of curve poles, using NURBS mathematics.
-     * 
+     * Shared v-direction pole solver — the single core both the plain loft and the
+     * spine loft route their pole computation through (issue #40 PR3 / #44).
+     *
+     * `B` holds the already-assembled right-hand sides: one column per
+     * (u-pole, spatial component) pair (`B.cols() == n_poles_u * dim`) and one row
+     * per v-direction degree of freedom (`B.rows() == nc * v.size()`). `nc` is the
+     * number of constraints interpolated at every section: 1 for the plain loft
+     * (positions only), 2 for the spine loft (position + spine tangent).
+     *
+     * The v-collocation matrix is assembled and factorized ONCE and every column is
+     * solved together as multiple right-hand sides (the PR2 batched/hoisted solve).
+     * The result is written straight into the surface's v-outer / u-inner pole
+     * layout, so neither caller needs a transpose round trip.
+     *
+     * @return A flattened vector of poles in the layout the surface ctor expects.
+     */
+    template <std::floating_point T, size_t dim, size_t nc>
+    auto build_loft_surface_poles_core(const MatrixX<T> &B, const std::vector<T> &flat_v,
+                                       const std::vector<T> &v, size_t q)
+        -> std::vector<std::array<T, dim>>
+    {
+        const size_t nv = v.size();
+        const auto n_poles_v = Eigen::Index(nc * nv);
+        const size_t nu = size_t(B.cols()) / dim;
+
+        MatrixX<T> N(n_poles_v, n_poles_v);
+        build_poles_matrix<T, nc>(flat_v, v, q, size_t(n_poles_v), N);
+        MatrixX<T> X = N.partialPivLu().solve(B);
+
+        std::vector<std::array<T, dim>> poles(size_t(n_poles_v) * nu);
+        for (Eigen::Index j = 0; j < n_poles_v; ++j)
+            for (size_t i = 0; i < nu; ++i)
+                for (size_t d = 0; d < dim; ++d)
+                    poles[size_t(j) * nu + i][d] = X(j, Eigen::Index(i * dim + d));
+
+        return poles;
+    }
+
+    /**
+     * Builds the poles for a (plain) loft surface from a set of curve poles, using
+     * NURBS mathematics. Thin wrapper over build_loft_surface_poles_core for the
+     * positions-only (nc == 1) case.
+     *
      * @param poles_curves The poles of the curves used to build the loft surface.
      * @param flat_v The flattened knot vector in the v direction.
      * @param v The knot vector in the v direction.
-     * @param flat_u The flattened knot vector in the u direction.
-     * @param p The degree of the curve in the u direction.
+     * @param flat_u The flattened knot vector in the u direction (unused; kept for API).
+     * @param p The degree of the curve in the u direction (unused; kept for API).
      * @param q The degree of the curve in the v direction.
      * @return A flattened vector of poles representing the loft surface.
      */
@@ -21,36 +62,19 @@ namespace gbs{
                             const std::vector<T> &flat_v, const std::vector<T> &v, const std::vector<T> &flat_u, size_t p,
                             size_t q)
     {
-        size_t ncr = poles_curves.size();
         size_t nu = poles_curves[0].size();
         size_t nv = poles_curves.size();
 
-        MatrixX<T> N(ncr, ncr);
-        build_poles_matrix<T, 1>(flat_v, v, q, ncr, N);
-        auto N_inv = N.partialPivLu();
-
-        // Assemble every right-hand side at once (one column per (u-index, dim))
-        // and solve them in a single batched back-substitution, reusing the single
-        // factorization above instead of one solve() per (i, d). The RHS is read
-        // straight from poles_curves[j][i][d] — no transpose copy — and the result
-        // is written directly into the flattened, v-outer/u-inner pole layout that
-        // the surface ctor expects, avoiding the former double transpose_poles +
-        // flatten_poles round trip (issue #40 PR2 / #44).
-        MatrixX<T> B(nv, Eigen::Index(nu * dim));
+        // Assemble every right-hand side at once (one column per (u-index, dim)),
+        // read straight from poles_curves[j][i][d] — no transpose copy — and let
+        // the shared core factorize once and batch-solve all columns.
+        MatrixX<T> B(Eigen::Index(nv), Eigen::Index(nu * dim));
         for (size_t i = 0; i < nu; ++i)
             for (size_t d = 0; d < dim; ++d)
                 for (size_t j = 0; j < nv; ++j)
                     B(Eigen::Index(j), Eigen::Index(i * dim + d)) = poles_curves[j][i][d];
 
-        MatrixX<T> X = N_inv.solve(B);
-
-        std::vector<std::array<T, dim>> poles(nu * nv);
-        for (size_t j = 0; j < nv; ++j)
-            for (size_t i = 0; i < nu; ++i)
-                for (size_t d = 0; d < dim; ++d)
-                    poles[j * nu + i][d] = X(Eigen::Index(j), Eigen::Index(i * dim + d));
-
-        return poles;
+        return build_loft_surface_poles_core<T, dim, 1>(B, flat_v, v, q);
     }
 
     /**

--- a/gbs/loft/loftCurves.h
+++ b/gbs/loft/loftCurves.h
@@ -1,197 +1,97 @@
 #pragma once
 #include "loftGeneric.h"
+#include <ranges>
+#include <initializer_list>
 
 namespace gbs{
-   /**
-     * Overload of the loft function for a vector of B-spline curves.
+
+    namespace detail {
+        // Extract (T, dim) from a loftable curve type. Specialized only for the
+        // curve kinds loft accepts, so it doubles as the membership test below.
+        template <typename C> struct loft_curve_traits;
+        template <typename T, size_t dim> struct loft_curve_traits<BSCurve<T, dim>> {
+            using value_type = T; static constexpr size_t dimension = dim;
+        };
+        template <typename T, size_t dim> struct loft_curve_traits<BSCurveRational<T, dim>> {
+            using value_type = T; static constexpr size_t dimension = dim;
+        };
+
+        template <typename> inline constexpr bool is_initializer_list_v = false;
+        template <typename U> inline constexpr bool is_initializer_list_v<std::initializer_list<U>> = true;
+
+        // A non-rational or rational B-spline curve loft knows how to consume.
+        template <typename C>
+        concept LoftableCurve = requires { typename loft_curve_traits<std::remove_cvref_t<C>>::value_type; };
+
+        // Any range of such curves (vector, list, …) — initializer_list is handled
+        // by its own overloads because a braced-init-list can't deduce a range.
+        template <typename R>
+        concept LoftableCurveRange =
+            !is_initializer_list_v<std::remove_cvref_t<R>> &&
+            std::ranges::input_range<R> &&
+            LoftableCurve<std::ranges::range_value_t<R>>;
+    }
+
+    /**
+     * Loft a range of B-spline curves through given v-parameters and v-degree.
      *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst Vector of B-spline curves.
+     * Handles every curve container (vector, list, …) and both rational and
+     * non-rational curves: the curve type drives degree/dimension deduction and the
+     * surface type (BSSurface vs BSSurfaceRational) via loft_generic's `if
+     * constexpr`. Collapses the former dozen near-identical overloads (issue #40
+     * PR3 / #44).
+     *
+     * @param bs_lst Range of B-spline curves.
      * @param v Parameter values in the 'v' direction.
      * @param q Degree of the lofted surface in the 'v' direction.
-     * @return A BSSurface object representing the lofted surface.
+     * @return A BSSurface / BSSurfaceRational representing the lofted surface.
      */
-    template <typename T, size_t dim>
-    auto loft(const std::vector<BSCurve<T, dim>> &bs_lst, const std::vector<T> &v, size_t q) -> BSSurface<T, dim>
+    template <typename R>
+        requires detail::LoftableCurveRange<R>
+    auto loft(const R &bs_lst,
+              const std::vector<typename detail::loft_curve_traits<std::ranges::range_value_t<R>>::value_type> &v,
+              size_t q)
     {
-        return loft_generic<T, dim>(bs_lst, v, q);
+        using Tr = detail::loft_curve_traits<std::ranges::range_value_t<R>>;
+        return loft_generic<typename Tr::value_type, Tr::dimension>(bs_lst.begin(), bs_lst.end(), v, q);
     }
 
     /**
-     * Overload of the loft function for a list of B-spline curves.
+     * Loft a range of B-spline curves, choosing the v-parametrization automatically
+     * and capping the v-degree at q_max. See the (range, v, q) overload above.
      *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q Degree of the lofted surface in the 'v' direction.
-     * @return A BSSurface object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::list<BSCurve<T, dim>> &bs_lst, const std::vector<T> &v, size_t q) -> BSSurface<T, dim>
-    {
-        return loft_generic<T, dim>(bs_lst, v, q);
-    }
-
-    /**
-     * Overload of the loft function for a initializer_list of B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q Degree of the lofted surface in the 'v' direction.
-     * @return A BSSurface object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::initializer_list<BSCurve<T, dim>> &bs_lst, const std::vector<T> &v, size_t q) -> BSSurface<T, dim>
-    {
-        return loft_generic<T, dim>(std::vector<BSCurve<T, dim>>{bs_lst}, v, q);
-    }
-
-    /**
-     * Overload of the loft function for a list of B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of B-spline curves.
-     * @param v Parameter values in the 'v' direction.
+     * @param bs_lst Range of B-spline curves.
      * @param q_max Maximal degree of the lofted surface in the 'v' direction. Default 3.
-     * @return A BSSurface object representing the lofted surface.
+     * @return A BSSurface / BSSurfaceRational representing the lofted surface.
      */
-    template <typename T, size_t dim>
-    auto loft(const std::list<BSCurve<T, dim>> &bs_lst, size_t q_max=3) -> BSSurface<T, dim>
+    template <typename R>
+        requires detail::LoftableCurveRange<R>
+    auto loft(const R &bs_lst, size_t q_max = 3)
     {
-        return loft_generic<T, dim>(bs_lst, q_max);
+        using Tr = detail::loft_curve_traits<std::ranges::range_value_t<R>>;
+        return loft_generic<typename Tr::value_type, Tr::dimension>(bs_lst.begin(), bs_lst.end(), q_max);
     }
 
     /**
-     * Overload of the loft function for a vector of B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q_max Maximal degree of the lofted surface in the 'v' direction. Default 3.
-     * @return A BSSurface object representing the lofted surface.
+     * initializer_list overload of loft (v, q) — a braced-init-list cannot deduce a
+     * generic range, so it gets its own entry point that materializes a vector.
      */
-    template <typename T, size_t dim>
-    auto loft(const std::vector<BSCurve<T, dim>> &bs_lst, size_t q_max=3) -> BSSurface<T, dim>
+    template <detail::LoftableCurve C>
+    auto loft(std::initializer_list<C> bs_lst,
+              const std::vector<typename detail::loft_curve_traits<C>::value_type> &v, size_t q)
     {
-        return loft_generic<T, dim>(bs_lst, q_max);
+        using Tr = detail::loft_curve_traits<C>;
+        return loft_generic<typename Tr::value_type, Tr::dimension>(std::vector<C>{bs_lst}, v, q);
     }
 
     /**
-     * Overload of the loft function for a initializer_list of B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q_max Maximal degree of the lofted surface in the 'v' direction. Default 3.
-     * @return A BSSurface object representing the lofted surface.
+     * initializer_list overload of loft (q_max) — see the (init_list, v, q) overload.
      */
-    template <typename T, size_t dim>
-    auto loft(const std::initializer_list<BSCurve<T, dim>> &bs_lst, size_t q_max=3) -> BSSurface<T, dim>
+    template <detail::LoftableCurve C>
+    auto loft(std::initializer_list<C> bs_lst, size_t q_max = 3)
     {
-        return loft_generic<T, dim>(std::vector<BSCurve<T, dim>>{bs_lst}, q_max);
-    }
-
-    /**
-     * Overload of the loft function for a vector of rational B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst Vector of rational B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q Degree of the lofted surface in the 'v' direction.
-     * @return A BSCurveRational object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::vector<BSCurveRational<T, dim>> &bs_lst, const std::vector<T> &v, size_t q) -> BSSurfaceRational<T, dim>
-    {
-        return loft_generic<T, dim>(bs_lst, v, q);
-    }
-
-    /**
-     * Overload of the loft function for a list of rational B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of rational B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q Degree of the lofted surface in the 'v' direction.
-     * @return A BSCurveRational object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::list<BSCurveRational<T, dim>> &bs_lst, const std::vector<T> &v, size_t q) -> BSSurfaceRational<T, dim>
-    {
-        return loft_generic<T, dim>(bs_lst, v, q);
-    }
-
-    /**
-     * Overload of the loft function for a initializer_list of rational B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of rational B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q Degree of the lofted surface in the 'v' direction.
-     * @return A BSCurveRational object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::initializer_list<BSCurveRational<T, dim>> &bs_lst, const std::vector<T> &v, size_t q) -> BSSurfaceRational<T, dim>
-    {
-        return loft_generic<T, dim>(std::vector<BSCurveRational<T, dim>>{bs_lst}, v, q);
-    }
-
-    /**
-     * Overload of the loft function for a list of rational B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of rational B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q_max Maximal degree of the lofted surface in the 'v' direction. Default 3.
-     * @return A BSCurveRational object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::list<BSCurveRational<T, dim>> &bs_lst, size_t q_max=3) -> BSSurfaceRational<T, dim>
-    {
-        return loft_generic<T, dim>(bs_lst, q_max);
-    }
-
-    /**
-     * Overload of the loft function for a vector of rational B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of rational B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q_max Maximal degree of the lofted surface in the 'v' direction. Default 3.
-     * @return A BSCurveRational object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::vector<BSCurveRational<T, dim>> &bs_lst, size_t q_max=3) -> BSSurfaceRational<T, dim>
-    {
-        return loft_generic<T, dim>(bs_lst, q_max);
-    }
-
-    /**
-     * Overload of the loft function for a initializer_list of rational B-spline curves.
-     *
-     * @tparam T Floating point type.
-     * @tparam dim Dimensionality.
-     * @param bs_lst List of rational B-spline curves.
-     * @param v Parameter values in the 'v' direction.
-     * @param q_max Maximal degree of the lofted surface in the 'v' direction. Default 3.
-     * @return A BSCurveRational object representing the lofted surface.
-     */
-    template <typename T, size_t dim>
-    auto loft(const std::initializer_list<BSCurveRational<T, dim>> &bs_lst, size_t q_max=3) -> BSSurfaceRational<T, dim>
-    {
-        return loft_generic<T, dim>(std::vector<BSCurveRational<T, dim>>{bs_lst}, q_max);
+        using Tr = detail::loft_curve_traits<C>;
+        return loft_generic<typename Tr::value_type, Tr::dimension>(std::vector<C>{bs_lst}, q_max);
     }
 
     /**


### PR DESCRIPTION
**PR3 (cleanup / dedup)** of the loft audit — the **last** of the loft series.
PR1 (#52, correctness) and PR2 (#53, perf) are already merged. Merging this
**Closes #40**. Part of the orchestration epic #44.

This is a refactor at **iso-functionality**: no behavioural change to any loft
entry point.

## What changed

### 1. Collapse the ~20 near-identical overloads (#40 finding #5)
`loft/loftCurves.h` previously carried **12** public `loft` overloads —
`BSCurve` / `BSCurveRational` × `vector` / `list` / `initializer_list` ×
`{v,q}` / `{q_max}` — all forwarding to `loft_generic`. They are replaced by:

- **two concept-constrained range templates** (`{v,q}` and `{q_max}`) that accept
  any range of loftable curves (vector, list, …), and
- **two `initializer_list` templates** (a braced-init-list can't deduce a generic
  range, so it needs its own entry point).

The curve type drives `T`/`dim` deduction and selects the return type
(`BSSurface` vs `BSSurfaceRational`) through `loft_generic`'s existing
`if constexpr`. The `shared_ptr<Curve>` approximation overloads keep their
`template<T,dim>` form so the pybind11 `overload_cast<…>(&gbs::loft<T,dim>)`
bindings still resolve.

### 2. One shared pole-solve core for spine and non-spine (#40 finding #6)
`loft/loftBase.h` gains `build_loft_surface_poles_core<nc>`: the single
v-direction pole solver — assemble + factorize the v-collocation matrix **once**,
batch-solve every `(u-pole, dim)` column as multiple RHS, and write the result
straight into the surface's pole layout.

- The plain loft's `build_loft_surface_poles(...)` keeps its exact signature
  (called directly by tests) and is now a thin `nc == 1` wrapper over the core,
  with the same zero-copy RHS fill introduced in PR2.
- The **spine loft** (`bssbuild.h`) now feeds its position + spine-tangent
  constraints (`nc == 2`) straight into that same core, replacing its bespoke
  `build_poles(Q_cols)` + `inverted_uv_poles` path. Spine and non-spine no longer
  carry parallel pole builders.

Net: **−85 lines**, 12 overloads → 4, two pole builders → one.

## Acceptance (#40)
- ✅ Zero behavioural change: all existing loft tests pass unchanged.
- ✅ Every loft input (vector / list / initializer_list, rational and not) remains
  callable with the same public signature — no API regression.
- ✅ A single shared core between spine and non-spine.

## Verification
Built & ran (doctest):

- `tests_bssbuild` — 15 cases / 2627 assertions ✅ (covers plain, rational,
  spine, gordon, `build_loft_surface_poles`, degree-clamp and rational-`flat_v`
  regression locks)
- `tests_bssurf` ✅, `tests_tojson` ✅, `tests_knotsfunctions` ✅, `tests_foils` ✅
- pybind11 loft binding TU (`gbsBindBuildSurfaces.cpp.o`) compiles ✅

File scope kept within the loft perimeter (`loft/*`, `bssbuild.h`, `loftBase.h`),
as the last PR of the series.