### PR TITLE
feat(eval): rational surface derivatives (Piegl & Tiller A4.4)

### DIFF
--- a/gbs/basisfunctions.ixx
+++ b/gbs/basisfunctions.ixx
@@ -564,6 +564,79 @@
         }
     }
 
+    /**
+     * @brief Rational BSpline surface mixed derivatives up to (nu, nv), one pass.
+     *
+     * Piegl & Tiller A4.4 ("The NURBS Book", RatSurfaceDerivs): the 2D
+     * generalisation of A4.2. Evaluate the homogeneous surface derivative table
+     * Aders[ku][kv] (numerator in the first dim coords, weight in the last) once
+     * via eval_ders_decasteljau on the weighted poles, then apply the rational
+     * quotient rule. Writes the projected derivatives row-major into
+     * SKL[ku*(nv+1)+kv].
+     *
+     * @param poles weighted poles (last coordinate is the weight)
+     * @param SKL   output buffer of at least (nu+1)*(nv+1) points
+     */
+    template <typename T, size_t dim>
+    void eval_rational_ders(T u, T v, const std::vector<T> &ku, const std::vector<T> &kv, const points_vector<T, dim + 1> &poles, size_t p, size_t q, size_t nu, size_t nv, std::array<T, dim> *SKL)
+    {
+        const size_t stride = nv + 1;
+
+        // A4.4 quotient rule on the homogeneous derivative table Aders.
+        const auto apply = [&](const std::array<T, dim + 1> *Aders)
+        {
+            const T w00 = Aders[0].back();
+            for (size_t k = 0; k <= nu; ++k)
+                for (size_t l = 0; l <= nv; ++l)
+                {
+                    std::array<T, dim> val;
+                    for (size_t c = 0; c < dim; ++c)
+                        val[c] = Aders[k * stride + l][c];
+                    // j-direction lower-order weighted terms (i == 0)
+                    for (size_t j = 1; j <= l; ++j)
+                    {
+                        const T b = binomial_law<T>(l, j) * Aders[j].back(); // wders[0][j]
+                        for (size_t c = 0; c < dim; ++c)
+                            val[c] -= b * SKL[k * stride + (l - j)][c];
+                    }
+                    for (size_t i = 1; i <= k; ++i)
+                    {
+                        const T bi = binomial_law<T>(k, i);
+                        const T wi0 = Aders[i * stride].back(); // wders[i][0]
+                        for (size_t c = 0; c < dim; ++c)
+                            val[c] -= bi * wi0 * SKL[(k - i) * stride + l][c];
+                        std::array<T, dim> v2{};
+                        for (size_t j = 1; j <= l; ++j)
+                        {
+                            const T b2 = binomial_law<T>(l, j) * Aders[i * stride + j].back(); // wders[i][j]
+                            for (size_t c = 0; c < dim; ++c)
+                                v2[c] += b2 * SKL[(k - i) * stride + (l - j)][c];
+                        }
+                        for (size_t c = 0; c < dim; ++c)
+                            val[c] -= bi * v2[c];
+                    }
+                    for (size_t c = 0; c < dim; ++c)
+                        SKL[k * stride + l][c] = val[c] / w00;
+                }
+        };
+
+        if (nu <= bspline_stack_max_degree && nv <= bspline_stack_max_degree)
+        {
+            // Stack buffer sized like the surface evaluator; one A2.3 pass per
+            // direction fills the (nu+1)x(nv+1) homogeneous table.
+            std::array<std::array<T, dim + 1>, (bspline_stack_max_degree + 1) * (bspline_stack_max_degree + 1)> Aders;
+            eval_ders_decasteljau<T, dim + 1>(u, v, ku, kv, poles, p, q, nu, nv, Aders.data());
+            apply(Aders.data());
+        }
+        else
+        {
+            // Pathological derivative order: heap-backed table (still one pass).
+            std::vector<std::array<T, dim + 1>> Aders((nu + 1) * (nv + 1));
+            eval_ders_decasteljau<T, dim + 1>(u, v, ku, kv, poles, p, q, nu, nv, Aders.data());
+            apply(Aders.data());
+        }
+    }
+
 
     // TODO Seems dead code
     /**

--- a/gbs/bssurf.h
+++ b/gbs/bssurf.h
@@ -817,20 +817,16 @@ namespace gbs
 
         virtual auto derivatives(T u, T v, size_t nu, size_t nv, std::array<T, dim>* SKL) const -> void override
         {
+            if (u < m_bounds[0] - knot_eps<T> || u > m_bounds[1] + knot_eps<T>)
+                throw OutOfBoundsSurfaceUEval<T>(u, this->boundsU());
+            if (v < m_bounds[2] - knot_eps<T> || v > m_bounds[3] + knot_eps<T>)
+                throw OutOfBoundsSurfaceVEval<T>(v, this->boundsV());
             if constexpr (rational)
-            {
-                // Rational surface derivatives are not implemented (value() throws
-                // for du>0 / dv>0); keep that behaviour via the base default.
-                Surface<T, dim>::derivatives(u, v, nu, nv, SKL);
-            }
+                // A4.4 quotient rule on the weighted (dim+1) poles; one A2.3 pass
+                // per direction yields every mixed order at once.
+                eval_rational_ders<T, dim>(u, v, m_knotsFlatsU, m_knotsFlatsV, m_poles, m_degU, m_degV, nu, nv, SKL);
             else
-            {
-                if (u < m_bounds[0] - knot_eps<T> || u > m_bounds[1] + knot_eps<T>)
-                    throw OutOfBoundsSurfaceUEval<T>(u, this->boundsU());
-                if (v < m_bounds[2] - knot_eps<T> || v > m_bounds[3] + knot_eps<T>)
-                    throw OutOfBoundsSurfaceVEval<T>(v, this->boundsV());
                 eval_ders_decasteljau(u, v, m_knotsFlatsU, m_knotsFlatsV, m_poles, m_degU, m_degV, nu, nv, SKL);
-            }
         }
 
         /**
@@ -1100,7 +1096,10 @@ namespace gbs
             }
             else
             {
-                throw std::runtime_error("not implemented");
+                // Mixed rational derivative via the one-pass A4.4 evaluator.
+                std::vector<std::array<T, dim>> SKL((du + 1) * (dv + 1));
+                this->derivatives(u, v, du, dv, SKL.data());
+                return SKL[du * (dv + 1) + dv];
             }
         }
 

--- a/tests/tests_surface_derivatives.cpp
+++ b/tests/tests_surface_derivatives.cpp
@@ -12,16 +12,48 @@ namespace
     // library's storage convention.
     //   S_u  = (1, 0, 2u),        S_v  = (0, 1, 2v)
     //   S_uu = (0, 0, 2),         S_vv = (0, 0, 2)
+    const std::vector<double> paraboloid_ku{0., 0., 0., 1., 1., 1.};
+    const std::vector<double> paraboloid_kv{0., 0., 0., 1., 1., 1.};
+    const gbs::points_vector<double, 3> paraboloid_poles{
+        {0., 0., 0.}, {0.5, 0., 0.}, {1., 0., 1.},
+        {0., 0.5, 0.}, {0.5, 0.5, 0.}, {1., 0.5, 1.},
+        {0., 1., 1.}, {0.5, 1., 1.}, {1., 1., 2.},
+    };
+
     gbs::BSSurface<double, 3> make_paraboloid()
+    {
+        return gbs::BSSurface<double, 3>(paraboloid_poles, paraboloid_ku, paraboloid_kv, 2, 2);
+    }
+
+    // Same control net as the paraboloid, promoted to rational with all weights
+    // equal to 1: the projected surface and all its derivatives must reproduce
+    // the non-rational ones to machine precision.
+    gbs::BSSurfaceRational<double, 3> make_unit_weight_paraboloid()
+    {
+        const std::vector<double> w(paraboloid_poles.size(), 1.0);
+        return gbs::BSSurfaceRational<double, 3>(paraboloid_poles, w, paraboloid_ku, paraboloid_kv, 2, 2);
+    }
+
+    // A genuinely weighted bidegree-(2,2) patch: a quarter-circle profile in the
+    // (x, z) plane (NURBS unit arc, weights 1, 1/sqrt(2), 1) swept linearly in y.
+    // The non-trivial middle weight exercises the A4.4 quotient rule.
+    gbs::BSSurfaceRational<double, 3> make_weighted_patch()
     {
         const std::vector<double> ku{0., 0., 0., 1., 1., 1.};
         const std::vector<double> kv{0., 0., 0., 1., 1., 1.};
+        const double s = 1.0 / std::sqrt(2.0);
+        // Arc control points (x, _, z); y filled per v-row below.
         const gbs::points_vector<double, 3> poles{
-            {0., 0., 0.}, {0.5, 0., 0.}, {1., 0., 1.},
-            {0., 0.5, 0.}, {0.5, 0.5, 0.}, {1., 0.5, 1.},
-            {0., 1., 1.}, {0.5, 1., 1.}, {1., 1., 2.},
+            {1., 0., 0.}, {1., 0., 1.}, {0., 0., 1.},
+            {1., 1., 0.}, {1., 1., 1.}, {0., 1., 1.},
+            {1., 2., 0.}, {1., 2., 1.}, {0., 2., 1.},
         };
-        return gbs::BSSurface<double, 3>(poles, ku, kv, 2, 2);
+        const std::vector<double> weights{
+            1., s, 1.,
+            1., s, 1.,
+            1., s, 1.,
+        };
+        return gbs::BSSurfaceRational<double, 3>(poles, weights, ku, kv, 2, 2);
     }
 }
 
@@ -250,4 +282,87 @@ TEST(tests_surface_derivatives, derivatives_match_per_order_value)
                         << "ku=" << ku_ << " kv=" << kv_ << " u=" << u << " v=" << v;
                 }
         }
+}
+
+// A rational surface with all weights == 1 must reproduce the non-rational
+// mixed derivatives to machine precision (the quotient rule collapses to the
+// homogeneous numerator). This catches the bulk of A4.4 transcription bugs.
+TEST(tests_surface_derivatives, rational_all_weights_one_matches_non_rational)
+{
+    const auto srf  = make_paraboloid();
+    const auto rsrf = make_unit_weight_paraboloid();
+    constexpr double tol = 1e-12;
+
+    for (double u : {0.0, 0.2, 0.5, 0.8, 1.0})
+    for (double v : {0.0, 0.2, 0.5, 0.8, 1.0})
+        for (size_t du : {size_t{0}, size_t{1}, size_t{2}})
+        for (size_t dv : {size_t{0}, size_t{1}, size_t{2}})
+        {
+            CAPTURE(u); CAPTURE(v); CAPTURE(du); CAPTURE(dv);
+            const auto ref = srf.value(u, v, du, dv);
+            const auto got = rsrf.value(u, v, du, dv);
+            for (size_t c = 0; c < 3; ++c)
+                EXPECT_NEAR(got[c], ref[c], tol);
+        }
+
+    // The arc-length helpers route through derivatives(); they must now work
+    // (no throw) on rational surfaces and match the non-rational values.
+    for (double u : {0.2, 0.5, 0.8})
+    for (double v : {0.2, 0.5, 0.8})
+    {
+        CAPTURE(u); CAPTURE(v);
+        const auto u2  = rsrf.d_dmu2(u, v);
+        const auto v2  = rsrf.d_dmv2(u, v);
+        const auto u2r = srf.d_dmu2(u, v);
+        const auto v2r = srf.d_dmv2(u, v);
+        for (size_t c = 0; c < 3; ++c)
+        {
+            EXPECT_NEAR(u2[c], u2r[c], tol);
+            EXPECT_NEAR(v2[c], v2r[c], tol);
+        }
+    }
+}
+
+// Weighted (genuine NURBS) derivatives must match central finite differences
+// of value(u, v, 0, 0). Looser tolerance because the reference is itself an
+// O(h^2) approximation.
+TEST(tests_surface_derivatives, rational_weighted_matches_finite_differences)
+{
+    const auto srf = make_weighted_patch();
+    const double h = 1e-4;
+    const double tol = 1e-6;
+
+    auto S = [&](double u, double v) { return srf.value(u, v, 0, 0); };
+
+    for (double u : {0.25, 0.5, 0.75})
+    for (double v : {0.25, 0.5, 0.75})
+    {
+        CAPTURE(u); CAPTURE(v);
+
+        const auto Su  = srf.value(u, v, 1, 0);
+        const auto Sv  = srf.value(u, v, 0, 1);
+        const auto Suu = srf.value(u, v, 2, 0);
+        const auto Svv = srf.value(u, v, 0, 2);
+        const auto Suv = srf.value(u, v, 1, 1);
+
+        const auto Sp0 = S(u + h, v), Sm0 = S(u - h, v);
+        const auto S0p = S(u, v + h), S0m = S(u, v - h);
+        const auto S00 = S(u, v);
+        const auto Spp = S(u + h, v + h), Spm = S(u + h, v - h);
+        const auto Smp = S(u - h, v + h), Smm = S(u - h, v - h);
+
+        for (size_t c = 0; c < 3; ++c)
+        {
+            const double fd_u  = (Sp0[c] - Sm0[c]) / (2 * h);
+            const double fd_v  = (S0p[c] - S0m[c]) / (2 * h);
+            const double fd_uu = (Sp0[c] - 2 * S00[c] + Sm0[c]) / (h * h);
+            const double fd_vv = (S0p[c] - 2 * S00[c] + S0m[c]) / (h * h);
+            const double fd_uv = (Spp[c] - Spm[c] - Smp[c] + Smm[c]) / (4 * h * h);
+            EXPECT_NEAR(Su[c],  fd_u,  tol);
+            EXPECT_NEAR(Sv[c],  fd_v,  tol);
+            EXPECT_NEAR(Suu[c], fd_uu, 1e-4);
+            EXPECT_NEAR(Svv[c], fd_vv, 1e-4);
+            EXPECT_NEAR(Suv[c], fd_uv, 1e-4);
+        }
+    }
 }

--- a/tests/tests_surface_derivatives.cpp
+++ b/tests/tests_surface_derivatives.cpp
@@ -322,7 +322,10 @@ TEST(tests_surface_derivatives, rational_all_weights_one_matches_non_rational)
         for (size_t du : {size_t{0}, size_t{1}, size_t{2}})
         for (size_t dv : {size_t{0}, size_t{1}, size_t{2}})
         {
-            CAPTURE(u); CAPTURE(v); CAPTURE(du); CAPTURE(dv);
+            CAPTURE(u);
+            CAPTURE(v);
+            CAPTURE(du);
+            CAPTURE(dv);
             const auto ref = srf.value(u, v, du, dv);
             const auto got = rsrf.value(u, v, du, dv);
             for (size_t c = 0; c < 3; ++c)
@@ -334,7 +337,8 @@ TEST(tests_surface_derivatives, rational_all_weights_one_matches_non_rational)
     for (double u : {0.2, 0.5, 0.8})
     for (double v : {0.2, 0.5, 0.8})
     {
-        CAPTURE(u); CAPTURE(v);
+        CAPTURE(u);
+        CAPTURE(v);
         const auto u2  = rsrf.d_dmu2(u, v);
         const auto v2  = rsrf.d_dmv2(u, v);
         const auto u2r = srf.d_dmu2(u, v);
@@ -361,7 +365,8 @@ TEST(tests_surface_derivatives, rational_weighted_matches_finite_differences)
     for (double u : {0.25, 0.5, 0.75})
     for (double v : {0.25, 0.5, 0.75})
     {
-        CAPTURE(u); CAPTURE(v);
+        CAPTURE(u);
+        CAPTURE(v);
 
         const auto Su  = srf.value(u, v, 1, 0);
         const auto Sv  = srf.value(u, v, 0, 1);
@@ -406,7 +411,8 @@ TEST(tests_surface_derivatives, d_dmu2_on_nurbs_circle_is_curvature_vector)
     for (double u : {0.0, 0.2, 0.4, 0.5, 0.6, 0.8, 1.0})
     for (double v : {0.0, 0.3, 0.7, 1.0})
     {
-        CAPTURE(u); CAPTURE(v);
+        CAPTURE(u);
+        CAPTURE(v);
         const auto P = srf.value(u, v, 0, 0);
 
         // Sanity: the (x, z) section lies exactly on the circle of radius R.

--- a/tests/tests_surface_derivatives.cpp
+++ b/tests/tests_surface_derivatives.cpp
@@ -55,6 +55,30 @@ namespace
         };
         return gbs::BSSurfaceRational<double, 3>(poles, weights, ku, kv, 2, 2);
     }
+
+    // Exact NURBS quarter-cylinder of radius R: a rational quadratic unit-circle
+    // arc (control points (R,0),(R,R),(0,R), weights 1, 1/sqrt(2), 1) in the
+    // (x, z) plane, swept linearly (degree 1) along y. The u-iso curves are exact
+    // circles of radius R, so the arc-length second derivative d_dmu2 has the
+    // closed form -(x, 0, z)/R^2 (curvature vector, |.| = 1/R); the straight
+    // v-rulings give d_dmv2 == 0.
+    constexpr double cylinder_R = 2.0;
+    gbs::BSSurfaceRational<double, 3> make_quarter_cylinder()
+    {
+        const std::vector<double> ku{0., 0., 0., 1., 1., 1.}; // degU = 2
+        const std::vector<double> kv{0., 0., 1., 1.};         // degV = 1
+        const double R = cylinder_R;
+        const gbs::points_vector<double, 3> poles{
+            {R, 0., 0.}, {R, 0., R}, {0., 0., R}, // y = 0 row
+            {R, R, 0.}, {R, R, R}, {0., R, R},    // y = R row
+        };
+        const double s = 1.0 / std::sqrt(2.0);
+        const std::vector<double> weights{
+            1., s, 1.,
+            1., s, 1.,
+        };
+        return gbs::BSSurfaceRational<double, 3>(poles, weights, ku, kv, 2, 1);
+    }
 }
 
 TEST(tests_surface_derivatives, d_dmu_is_unit_tangent_along_u)
@@ -364,5 +388,41 @@ TEST(tests_surface_derivatives, rational_weighted_matches_finite_differences)
             EXPECT_NEAR(Svv[c], fd_vv, 1e-4);
             EXPECT_NEAR(Suv[c], fd_uv, 1e-4);
         }
+    }
+}
+
+// Arc-length second derivative on an exact NURBS circle. For the radius-R
+// quarter-cylinder, the u-iso curves are exact circles, so d_dmu2 is the
+// curvature vector: it points from the surface point to the axis with
+// magnitude 1/R, i.e. d_dmu2 == -(x, 0, z)/R^2. The straight v-rulings give
+// d_dmv2 == 0. Both hold to machine precision (exact rational geometry,
+// closed-form A4.4 derivatives -- no finite differencing).
+TEST(tests_surface_derivatives, d_dmu2_on_nurbs_circle_is_curvature_vector)
+{
+    const auto srf = make_quarter_cylinder();
+    const double R = cylinder_R;
+    constexpr double tol = 1e-11;
+
+    for (double u : {0.0, 0.2, 0.4, 0.5, 0.6, 0.8, 1.0})
+    for (double v : {0.0, 0.3, 0.7, 1.0})
+    {
+        CAPTURE(u); CAPTURE(v);
+        const auto P = srf.value(u, v, 0, 0);
+
+        // Sanity: the (x, z) section lies exactly on the circle of radius R.
+        EXPECT_NEAR(P[0] * P[0] + P[2] * P[2], R * R, tol);
+
+        // Curvature vector of the u-iso circle: toward the axis, magnitude 1/R.
+        const auto a = srf.d_dmu2(u, v);
+        EXPECT_NEAR(a[0], -P[0] / (R * R), tol);
+        EXPECT_NEAR(a[1], 0.0,             tol);
+        EXPECT_NEAR(a[2], -P[2] / (R * R), tol);
+        EXPECT_NEAR(std::sqrt(a[0]*a[0] + a[1]*a[1] + a[2]*a[2]), 1.0 / R, tol);
+
+        // The v-rulings are straight lines: zero arc-length curvature.
+        const auto b = srf.d_dmv2(u, v);
+        EXPECT_NEAR(b[0], 0.0, tol);
+        EXPECT_NEAR(b[1], 0.0, tol);
+        EXPECT_NEAR(b[2], 0.0, tol);
     }
 }


### PR DESCRIPTION
## Summary

Implements derivatives for `BSSurfaceRational` so `value(u, v, du, dv)` with
`du > 0` / `dv > 0` no longer throws `"not implemented"`. This was the last
gap in the curve/surface derivative core after #30/#31/#32.

## What changed

- **`basisfunctions.ixx`** — new surface `eval_rational_ders` (NURBS Book
  Algorithm **A4.4**, *RatSurfaceDerivs*), the 2D generalisation of the A4.2
  used for rational curves. It calls the existing one-pass
  `eval_ders_decasteljau` on the weighted `(dim+1)` poles to build the
  homogeneous numerator/weight derivative table in a single A2.3 pass per
  direction, then applies the nested binomial quotient rule. Stack-buffered
  table for the common orders (`<= bspline_stack_max_degree`), heap fallback
  only for pathological derivative order; degree blow-up is handled inside
  `eval_ders_decasteljau`'s own recursive fallback.
- **`bssurf.h`** — route the `if constexpr (rational)` branch of
  `BSSurfaceGeneral::derivatives` to the new helper (bounds check hoisted out,
  shared by both branches), and make `BSSurfaceRational::value` evaluate
  non-zero orders via `derivatives`. `d_dmu2` / `d_dmv2` now work on rational
  surfaces.

## Validation

There is no pre-existing `value(du>0)` reference for rational surfaces, so:

- **exact** — a rational surface with all weights `= 1` reproduces the
  non-rational mixed derivatives (orders up to 2 in each direction) to machine
  precision (`1e-12`), including `d_dmu2`/`d_dmv2`.
- **weighted** — a genuine NURBS patch (quarter-circle profile swept linearly,
  middle weight `1/sqrt(2)`) matches central finite differences of
  `value(u, v, 0, 0)`.

All four eval/surface test targets pass
(`tests_basisfunctions`, `tests_bscurve`, `tests_surface_derivatives`,
`tests_surfaces`).

Closes #33. Part of the epic in #44.