### PR TITLE
Harden Bowyer-Watson cavity construction (#48)

### DIFF
--- a/inc/topology/robustPredicates.h
+++ b/inc/topology/robustPredicates.h
@@ -1,0 +1,370 @@
+#pragma once
+
+// Exact-sign 2D geometric predicates (adaptive precision).
+//
+// This is a templated C++ port of the orientation predicate from Jonathan
+// Richard Shewchuk's public-domain "Routines for Arbitrary Precision
+// Floating-Point Arithmetic and Fast Robust Geometric Predicates"
+// (https://www.cs.cmu.edu/~quake/robust.html). `orient2d` returns a value whose
+// SIGN is the exact sign of the 2x2 determinant
+//
+//     | ax-cx  ay-cy |
+//     | bx-cx  by-cy |
+//
+// i.e. > 0 iff (a,b,c) turns counter-clockwise, regardless of floating-point
+// rounding. A fast floating-point filter handles the common, well-separated
+// case; only near-degenerate inputs fall back to the exact expansion path. The
+// sign is therefore identical on every platform/compiler, which is what the
+// half-edge tessellation needs to build a robust, deterministic mesh
+// (cf. issue #48).
+//
+// The expansion arithmetic relies on IEEE-754 round-to-nearest and on the
+// intermediate products/sums NOT being fused (an FMA contraction of `a*b - c*d`
+// would defeat the error-free transformations). We disable contraction for this
+// translation-unit region; the algorithm is otherwise standard-conforming.
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma STDC FP_CONTRACT OFF
+#endif
+
+#include <array>
+#include <concepts>
+#include <limits>
+#include <cmath>
+
+namespace gbs
+{
+namespace robust_predicates
+{
+    /// Compile-time constants of Shewchuk's scheme, derived from the type's
+    /// machine epsilon. `epsilon` is half an ulp of 1 (round-to-nearest), the
+    /// `splitter` is 2^ceil(p/2)+1 used to split a mantissa in two halves, and
+    /// the error bounds are the polynomials given in predicates.c.
+    template <std::floating_point T>
+    struct constants
+    {
+        static constexpr T epsilon = std::numeric_limits<T>::epsilon() / T{2};
+
+        static constexpr T compute_splitter()
+        {
+            // 2^( ceil(digits/2) ) + 1, computed exactly in floating point.
+            T s{1};
+            for (int i = 0; i < (std::numeric_limits<T>::digits + 1) / 2; ++i)
+            {
+                s *= T{2};
+            }
+            return s + T{1};
+        }
+
+        static constexpr T splitter        = compute_splitter();
+        static constexpr T resulterrbound  = (T{3} + T{8} * epsilon) * epsilon;
+        static constexpr T ccwerrboundA    = (T{3} + T{16} * epsilon) * epsilon;
+        static constexpr T ccwerrboundB    = (T{2} + T{12} * epsilon) * epsilon;
+        static constexpr T ccwerrboundC    = (T{9} + T{64} * epsilon) * epsilon * epsilon;
+    };
+
+    // --- Error-free transformations (Shewchuk / Dekker / Knuth) --------------
+
+    /// x = fl(a+b), y = a+b-x exactly. No magnitude assumption.
+    template <std::floating_point T>
+    inline void two_sum(T a, T b, T &x, T &y)
+    {
+        x = a + b;
+        T bvirt  = x - a;
+        T avirt  = x - bvirt;
+        T bround = b - bvirt;
+        T around = a - avirt;
+        y = around + bround;
+    }
+
+    /// Tail of a-b given the already-rounded difference x = fl(a-b).
+    template <std::floating_point T>
+    inline void two_diff_tail(T a, T b, T x, T &y)
+    {
+        T bvirt  = a - x;
+        T avirt  = x + bvirt;
+        T bround = bvirt - b;
+        T around = a - avirt;
+        y = around + bround;
+    }
+
+    /// x = fl(a-b), y = a-b-x exactly.
+    template <std::floating_point T>
+    inline void two_diff(T a, T b, T &x, T &y)
+    {
+        x = a - b;
+        two_diff_tail(a, b, x, y);
+    }
+
+    /// x = fl(a+b), y tail; requires |a| >= |b|.
+    template <std::floating_point T>
+    inline void fast_two_sum(T a, T b, T &x, T &y)
+    {
+        x = a + b;
+        T bvirt = x - a;
+        y = b - bvirt;
+    }
+
+    /// Split a p-bit value into two non-overlapping halves.
+    template <std::floating_point T>
+    inline void split(T a, T &ahi, T &alo)
+    {
+        T c    = constants<T>::splitter * a;
+        T abig = c - a;
+        ahi    = c - abig;
+        alo    = a - ahi;
+    }
+
+    /// x = fl(a*b), y = a*b-x exactly.
+    template <std::floating_point T>
+    inline void two_product(T a, T b, T &x, T &y)
+    {
+        x = a * b;
+        T ahi, alo, bhi, blo;
+        split(a, ahi, alo);
+        split(b, bhi, blo);
+        T err1 = x - (ahi * bhi);
+        T err2 = err1 - (alo * bhi);
+        T err3 = err2 - (ahi * blo);
+        y = (alo * blo) - err3;
+    }
+
+    /// (a1,a0) - b  ->  (x2,x1,x0)
+    template <std::floating_point T>
+    inline void two_one_diff(T a1, T a0, T b, T &x2, T &x1, T &x0)
+    {
+        T i;
+        two_diff(a0, b, i, x0);
+        two_sum(a1, i, x2, x1);
+    }
+
+    /// (a1,a0) - (b1,b0)  ->  (x3,x2,x1,x0)
+    template <std::floating_point T>
+    inline void two_two_diff(T a1, T a0, T b1, T b0, T &x3, T &x2, T &x1, T &x0)
+    {
+        T j, z0;
+        two_one_diff(a1, a0, b0, j, z0, x0);
+        two_one_diff(j, z0, b1, x3, x2, x1);
+    }
+
+    /// Sum of the components of an expansion (its rounded value).
+    template <std::floating_point T>
+    inline T estimate(int elen, const T *e)
+    {
+        T Q = e[0];
+        for (int i = 1; i < elen; ++i)
+        {
+            Q += e[i];
+        }
+        return Q;
+    }
+
+    /// h = e + f, both non-overlapping increasing-magnitude expansions, with
+    /// zero components eliminated. |h| <= elen+flen. The one-past reads of the
+    /// canonical C version are guarded so we never index out of bounds.
+    template <std::floating_point T>
+    inline int fast_expansion_sum_zeroelim(int elen, const T *e, int flen, const T *f, T *h)
+    {
+        T Q, Qnew, hh;
+        int eindex = 0, findex = 0, hindex = 0;
+        T enow = e[0];
+        T fnow = f[0];
+
+        if ((fnow > enow) == (fnow > -enow))
+        {
+            Q = enow;
+            ++eindex;
+            if (eindex < elen) enow = e[eindex];
+        }
+        else
+        {
+            Q = fnow;
+            ++findex;
+            if (findex < flen) fnow = f[findex];
+        }
+
+        if ((eindex < elen) && (findex < flen))
+        {
+            if ((fnow > enow) == (fnow > -enow))
+            {
+                fast_two_sum(enow, Q, Qnew, hh);
+                ++eindex;
+                if (eindex < elen) enow = e[eindex];
+            }
+            else
+            {
+                fast_two_sum(fnow, Q, Qnew, hh);
+                ++findex;
+                if (findex < flen) fnow = f[findex];
+            }
+            Q = Qnew;
+            if (hh != T{0}) h[hindex++] = hh;
+
+            while ((eindex < elen) && (findex < flen))
+            {
+                if ((fnow > enow) == (fnow > -enow))
+                {
+                    two_sum(Q, enow, Qnew, hh);
+                    ++eindex;
+                    if (eindex < elen) enow = e[eindex];
+                }
+                else
+                {
+                    two_sum(Q, fnow, Qnew, hh);
+                    ++findex;
+                    if (findex < flen) fnow = f[findex];
+                }
+                Q = Qnew;
+                if (hh != T{0}) h[hindex++] = hh;
+            }
+        }
+
+        while (eindex < elen)
+        {
+            two_sum(Q, enow, Qnew, hh);
+            ++eindex;
+            if (eindex < elen) enow = e[eindex];
+            Q = Qnew;
+            if (hh != T{0}) h[hindex++] = hh;
+        }
+        while (findex < flen)
+        {
+            two_sum(Q, fnow, Qnew, hh);
+            ++findex;
+            if (findex < flen) fnow = f[findex];
+            Q = Qnew;
+            if (hh != T{0}) h[hindex++] = hh;
+        }
+
+        if ((Q != T{0}) || (hindex == 0))
+        {
+            h[hindex++] = Q;
+        }
+        return hindex;
+    }
+
+    /// Adaptive stage of orient2d once the cheap filter is inconclusive.
+    template <std::floating_point T>
+    T orient2d_adapt(const std::array<T, 2> &pa,
+                     const std::array<T, 2> &pb,
+                     const std::array<T, 2> &pc,
+                     T detsum)
+    {
+        using K = constants<T>;
+
+        T acx = pa[0] - pc[0];
+        T bcx = pb[0] - pc[0];
+        T acy = pa[1] - pc[1];
+        T bcy = pb[1] - pc[1];
+
+        T detleft, detlefttail, detright, detrighttail;
+        two_product(acx, bcy, detleft, detlefttail);
+        two_product(acy, bcx, detright, detrighttail);
+
+        T B[4];
+        two_two_diff(detleft, detlefttail, detright, detrighttail, B[3], B[2], B[1], B[0]);
+
+        T det = estimate(4, B);
+        T errbound = K::ccwerrboundB * detsum;
+        if ((det >= errbound) || (-det >= errbound))
+        {
+            return det;
+        }
+
+        T acxtail, bcxtail, acytail, bcytail;
+        two_diff_tail(pa[0], pc[0], acx, acxtail);
+        two_diff_tail(pb[0], pc[0], bcx, bcxtail);
+        two_diff_tail(pa[1], pc[1], acy, acytail);
+        two_diff_tail(pb[1], pc[1], bcy, bcytail);
+
+        if (acxtail == T{0} && acytail == T{0} && bcxtail == T{0} && bcytail == T{0})
+        {
+            return det;
+        }
+
+        errbound = K::ccwerrboundC * detsum + K::resulterrbound * std::abs(det);
+        det += (acx * bcytail + bcy * acxtail) - (acy * bcxtail + bcx * acytail);
+        if ((det >= errbound) || (-det >= errbound))
+        {
+            return det;
+        }
+
+        T s1, s0, t1, t0;
+        T u[4];
+
+        two_product(acxtail, bcy, s1, s0);
+        two_product(acytail, bcx, t1, t0);
+        two_two_diff(s1, s0, t1, t0, u[3], u[2], u[1], u[0]);
+        T C1[8];
+        int C1len = fast_expansion_sum_zeroelim(4, B, 4, u, C1);
+
+        two_product(acx, bcytail, s1, s0);
+        two_product(acy, bcxtail, t1, t0);
+        two_two_diff(s1, s0, t1, t0, u[3], u[2], u[1], u[0]);
+        T C2[12];
+        int C2len = fast_expansion_sum_zeroelim(C1len, C1, 4, u, C2);
+
+        two_product(acxtail, bcytail, s1, s0);
+        two_product(acytail, bcxtail, t1, t0);
+        two_two_diff(s1, s0, t1, t0, u[3], u[2], u[1], u[0]);
+        T D[16];
+        int Dlen = fast_expansion_sum_zeroelim(C2len, C2, 4, u, D);
+
+        return D[Dlen - 1];
+    }
+} // namespace robust_predicates
+
+/**
+ * @brief Exact-sign orientation of the triangle (a,b,c).
+ *
+ * Returns a value with the same sign as the exact 2x2 determinant: positive iff
+ * (a,b,c) is counter-clockwise, negative iff clockwise, exactly zero iff the
+ * three points are collinear. The magnitude approximates the signed area times
+ * two but is only guaranteed for its sign. Unlike a raw floating-point
+ * determinant, the sign is robust and reproducible across platforms.
+ *
+ * @tparam T Floating-point type.
+ */
+template <std::floating_point T>
+T orient2d(const std::array<T, 2> &pa, const std::array<T, 2> &pb, const std::array<T, 2> &pc)
+{
+    using K = robust_predicates::constants<T>;
+
+    T detleft  = (pa[0] - pc[0]) * (pb[1] - pc[1]);
+    T detright = (pa[1] - pc[1]) * (pb[0] - pc[0]);
+    T det      = detleft - detright;
+
+    T detsum;
+    if (detleft > T{0})
+    {
+        if (detright <= T{0})
+            return det;
+        detsum = detleft + detright;
+    }
+    else if (detleft < T{0})
+    {
+        if (detright >= T{0})
+            return det;
+        detsum = -detleft - detright;
+    }
+    else
+    {
+        return det;
+    }
+
+    T errbound = K::ccwerrboundA * detsum;
+    if ((det >= errbound) || (-det >= errbound))
+    {
+        return det;
+    }
+
+    return robust_predicates::orient2d_adapt(pa, pb, pc, detsum);
+}
+
+} // namespace gbs
+
+// Restore the default contraction setting for the rest of the translation unit
+// so including this header does not silently change other code's FP behaviour.
+#if defined(__clang__) || defined(__GNUC__)
+#pragma STDC FP_CONTRACT DEFAULT
+#endif

--- a/inc/topology/tessellations.h
+++ b/inc/topology/tessellations.h
@@ -20,6 +20,7 @@
 #include "halfEdgeMeshSmoothing.h"
 #include "edgeRecovery.h"
 #include "baseGeom.h"
+#include "robustPredicates.h"
 
 namespace gbs
 {
@@ -62,59 +63,183 @@ namespace gbs
         return coords;
     }
 
+namespace bw_detail
+{
+    /// The three vertex coordinates of a triangular face in CCW (face) order.
+    template <std::floating_point T>
+    inline std::array<std::array<T, 2>, 3>
+    triangle_coords_ccw(const std::shared_ptr<HalfEdgeFace<T, 2>> &f)
+    {
+        auto e = f->edge;
+        return {e->vertex->coords, e->next->vertex->coords, e->next->next->vertex->coords};
+    }
+
+    /// True iff xy is strictly on the interior side of every half-edge of the
+    /// (CCW) cavity boundary loop, i.e. the cavity is star-shaped w.r.t. xy.
+    ///
+    /// Each fan triangle add_vertex() builds from a boundary half-edge A->B is
+    /// (A, B, xy); it is strictly counter-clockwise iff orient2d(A, B, xy) > 0.
+    /// So this exact-predicate check, run BEFORE any mutation, is the runtime
+    /// guarantee that the re-triangulation contains no degenerate/overlapping
+    /// triangle — and it holds on every platform (CI builds Release/NDEBUG, so
+    /// the assert() guards below are not a substitute, cf. issue #48).
+    template <std::floating_point T>
+    inline bool is_star_shaped(const std::list<std::shared_ptr<HalfEdge<T, 2>>> &loop,
+                               const std::array<T, 2> &xy)
+    {
+        if (loop.empty())
+            return false;
+        for (const auto &he : loop)
+        {
+            const auto &A = he->previous->vertex->coords;
+            const auto &B = he->vertex->coords;
+            if (orient2d(A, B, xy) <= T{0})
+                return false;
+        }
+        return true;
+    }
+} // namespace bw_detail
+
 /**
- * @brief Inserts a point into a Delaunay triangulation using the Boyer-Watson algorithm.
+ * @brief Inserts a point into a Delaunay triangulation using the Bowyer-Watson algorithm.
+ *
+ * Hardened cavity construction (cf. issue #48):
+ *   1. Locate the triangle (or the two triangles sharing an edge) whose closed
+ *      region contains @p xy, using the exact-sign orient2d predicate so the
+ *      classification is robust and platform-independent.
+ *   2. Grow the cavity by CONNECTIVITY: flood-fill across shared edges, adding a
+ *      neighbour iff @p xy is strictly inside its circumcircle. This yields a
+ *      single connected region (no detached faces collected by a global search).
+ *   3. Validate at RUNTIME that the cavity boundary is exactly one star-shaped
+ *      loop w.r.t. @p xy (exact orient2d). If not — a degenerate configuration —
+ *      fall back to the minimal containing cavity, which is always star-shaped.
+ * The fan re-triangulation then provably contains no overlapping triangle, so
+ * the meshed area equals the true domain area on every platform.
  *
  * @tparam T A floating-point type used for coordinates and tolerance values.
  * @tparam Container A container type representing the list of HalfEdgeFaces.
  * @param h_f_lst A reference to the container of HalfEdgeFaces forming the initial Delaunay triangulation.
  * @param xy An array containing the coordinates of the point to be inserted.
- * @param tol A floating-point value used as tolerance for the Delaunay condition (default is 1e-10).
+ * @param tol Unused; retained for API compatibility (the cavity is now built by
+ *            connectivity + exact predicates rather than a positive threshold).
  * @return A tuple ( new vertex, deleted HalfEdgeFaces that were violating the Delaunay condition, the newly created HalfEdgeFaces).
  */
     template<std::floating_point T, typename Container>
     auto boyerWatson(Container& h_f_lst, const std::array<T, 2>& xy, T tol = T{1e-10}) {
         using std::begin;
         using std::end;
+        using Face = std::shared_ptr<HalfEdgeFace<T, 2>>;
+        using EmptyTuple = std::tuple<std::shared_ptr<HalfEdgeVertex<T, 2>>, Container, Container>;
+        (void)tol;
 
-        auto it{begin(h_f_lst)};
-        Container h_f_lst_deleted;
+        // 1. Locate the containing triangle(s) with exact orientation tests.
+        std::vector<Face> seed;
+        bool duplicate = false;
+        for (const auto &f : h_f_lst)
+        {
+            auto [a, b, c] = bw_detail::triangle_coords_ccw<T>(f);
+            if (xy == a || xy == b || xy == c)
+            {
+                duplicate = true; // point coincides with an existing vertex
+                break;
+            }
+            T o0 = orient2d(a, b, xy);
+            T o1 = orient2d(b, c, xy);
+            T o2 = orient2d(c, a, xy);
+            if (o0 < T{0} || o1 < T{0} || o2 < T{0})
+                continue; // xy is outside this triangle
 
-        // Find triangle violation Delaunay condition
-        //
-        // FRAGILE (cf. issue #48) : la cavite est collectee par un find_if global,
-        // sans contrainte de connexite, avec un seuil positif asymetrique (> tol).
-        // Combine a in_circle qui est un determinant en flottant pur (signe non
-        // robuste pres d'une config degeneree), cela peut produire une cavite
-        // non-connexe ou non-etoilee vis-a-vis de xy : l'eventail add_vertex cree
-        // alors des triangles qui se chevauchent (aire du maillage > aire reelle).
-        // Sensible a la plateforme (libstdc++ vs libc++). Les assert are_face_ccw
-        // ci-dessous l'attraperaient, mais sont desactives en Release (CI).
-        // A corriger : cavite par propagation de connexite depuis le triangle
-        // contenant xy + predicats a signe exact (Shewchuk).
-        while (it != end(h_f_lst)) {
-            it = find_if(it, end(h_f_lst), [xy, tol](const auto& h_f) {
-                return in_circle(xy, h_f) > tol;
-            });
-            if (it != end(h_f_lst)) {
-                h_f_lst_deleted.push_back(*it);
-                it = h_f_lst.erase(it);
+            seed.push_back(f);
+            if (o0 == T{0} || o1 == T{0} || o2 == T{0})
+            {
+                // xy lies on an edge: pull in the neighbour across that edge so
+                // the edge becomes interior to the cavity (xy strictly inside).
+                auto e = f->edge;
+                std::shared_ptr<HalfEdge<T, 2>> on = (o0 == T{0}) ? e->next
+                                                  : (o1 == T{0}) ? e->next->next
+                                                                 : e;
+                if (on && on->opposite && on->opposite->face)
+                    seed.push_back(on->opposite->face);
+            }
+            break;
+        }
+        if (duplicate || seed.empty())
+            return EmptyTuple{}; // outside the mesh or confused with an existing point
+
+        // 2. Grow a connected cavity: a neighbour joins iff xy is strictly inside
+        //    its circumcircle (symmetric > 0, no asymmetric positive tolerance).
+        std::unordered_set<HalfEdgeFace<T, 2> *> in_cavity;
+        std::vector<Face> cavity;
+        std::vector<Face> stack;
+        for (const auto &f : seed)
+            if (in_cavity.insert(f.get()).second)
+            {
+                cavity.push_back(f);
+                stack.push_back(f);
+            }
+        while (!stack.empty())
+        {
+            auto f = stack.back();
+            stack.pop_back();
+            for (const auto &he : getTriangleEdges(f))
+            {
+                if (!he->opposite || !he->opposite->face)
+                    continue;
+                auto nf = he->opposite->face;
+                if (in_cavity.count(nf.get()))
+                    continue;
+                if (in_circle(xy, nf) > T{0})
+                {
+                    in_cavity.insert(nf.get());
+                    cavity.push_back(nf);
+                    stack.push_back(nf);
+                }
             }
         }
 
-        if (h_f_lst_deleted.empty()) {
-            return std::tuple<std::shared_ptr<HalfEdgeVertex<T, 2>>,Container, Container>{}; // if point is outside or confused with an existing point
+        // 3. Validate: a single star-shaped boundary loop. Fall back to the
+        //    minimal containing cavity (always star-shaped) on any degeneracy.
+        auto boundary_loops = [](const std::vector<Face> &faces) {
+            return getOrientedFacesBoundaries(std::list<Face>(faces.begin(), faces.end()));
+        };
+
+        auto loops = boundary_loops(cavity);
+        bool ok = loops.size() == 1 && bw_detail::is_star_shaped<T>(loops.front(), xy);
+        if (!ok)
+        {
+            cavity.assign(seed.begin(), seed.end());
+            loops = boundary_loops(cavity);
+            ok = loops.size() == 1 && bw_detail::is_star_shaped<T>(loops.front(), xy);
+        }
+        if (!ok)
+            return EmptyTuple{}; // give up rather than corrupt the mesh
+
+        // 4. Remove the cavity faces. Their boundary half-edges stay alive and
+        //    are recycled by add_vertex to stitch the fan to the surrounding
+        //    mesh, preserving opposite links (same contract as before).
+        std::unordered_set<HalfEdgeFace<T, 2> *> cavity_set;
+        for (const auto &f : cavity)
+            cavity_set.insert(f.get());
+        Container h_f_lst_deleted;
+        for (auto it = begin(h_f_lst); it != end(h_f_lst);)
+        {
+            if (cavity_set.count(it->get()))
+            {
+                h_f_lst_deleted.push_back(*it);
+                it = h_f_lst.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
         }
 
-        assert(are_face_ccw(h_f_lst));
-
-        // Get cavity boundary
-        auto h_e_lst = getOrientedFacesBoundary(h_f_lst_deleted);
-        assert(are_edges_2d_ccw<T>(h_e_lst));
-
         // fill cavity
+        auto &h_e_lst = loops.front();
+        assert(are_edges_2d_ccw<T>(h_e_lst));
         auto vtx = make_shared_h_vertex(xy);
-        auto h_f_lst_new = add_vertex(h_e_lst, vtx);
+        Container h_f_lst_new = add_vertex(h_e_lst, vtx);
+        // is_star_shaped above is the runtime guarantee; this only re-checks in debug.
         assert(are_face_ccw(h_f_lst_new));
 
         // append new faces

--- a/tests/tests_baseIntersections.cpp
+++ b/tests/tests_baseIntersections.cpp
@@ -1,7 +1,9 @@
 #include <chrono>
 #include <doctest_gtest.hpp>
 #include <topology/baseIntersection.h>
+#include <topology/robustPredicates.h>
 #include <array>
+#include <cmath>
 
 #ifdef GBS_USE_MODULES
     import vecop;
@@ -81,6 +83,74 @@ TEST(base_intersections, in_circle)
             );
         }
     }
+}
+
+TEST(base_intersections, orient2d_robust_exact)
+{
+    using gbs::orient2d;
+    using gbs::orient_2d;
+
+    // Basic sign agreement on a well-separated, non-degenerate triangle.
+    {
+        std::array<double, 2> a{0.0, 0.0}, b{1.0, 0.0}, c{0.0, 1.0};
+        ASSERT_GT(orient2d(a, b, c), 0.0); // CCW
+        ASSERT_LT(orient2d(a, c, b), 0.0); // CW
+        ASSERT_EQ(orient2d(a, b, a), 0.0); // degenerate -> exactly zero
+    }
+
+    // Hand-crafted near-degenerate configuration: the exact orientation is +1
+    // (origin O w.r.t. the directed segment A->B) but the products A.x*B.y and
+    // A.y*B.x both round to the SAME double, so the naive determinant cancels to
+    // 0 (or, with FMA contraction, to some other value). The robust predicate
+    // must still report the exact sign. This is exactly the failure mode that
+    // made the cavity construction platform-dependent (cf. issue #48).
+    {
+        const double p = std::ldexp(1.0, 27); // 2^27, exactly representable
+        std::array<double, 2> A{p + 1.0, p}, B{p + 2.0, p + 1.0}, O{0.0, 0.0};
+        // exact: A.x*B.y - A.y*B.x = (2^27+1)(2^27+1) - (2^27)(2^27+2) = +1
+        ASSERT_GT(orient2d(A, B, O), 0.0);
+        ASSERT_LT(orient2d(B, A, O), 0.0);
+    }
+
+#ifdef __SIZEOF_INT128__
+    // Torture test against an exact 128-bit integer reference, on near-parallel
+    // configurations (heavy cancellation). The robust predicate's sign must
+    // match the exact sign on every single case.
+    {
+        std::mt19937_64 gen(0xB0BCA7ULL);
+        // k near 2^27 so the cross products k*(k+.) are near 2^54, where a double
+        // can no longer represent consecutive integers: the exact determinant is
+        // +/-1 but lives entirely in the rounding noise of the products.
+        std::uniform_int_distribution<long long> kbig(1LL << 26, (1LL << 27) - 3);
+
+        const size_t n = 100000;
+        size_t naive_wrong = 0;
+        for (size_t i = 0; i < n; ++i)
+        {
+            long long k = kbig(gen);
+            long long ax = k + 1, ay = k, bx = k + 2, by = k + 1; // exact det = +1
+            int sref = 1;
+            if (gen() & 1ULL) // swap a<->b => exact det = -1
+            {
+                std::swap(ax, bx);
+                std::swap(ay, by);
+                sref = -1;
+            }
+
+            std::array<double, 2> A{(double)ax, (double)ay}, B{(double)bx, (double)by}, O{0.0, 0.0};
+            double r = orient2d(A, B, O);
+            int srob = (r > 0) - (r < 0);
+            ASSERT_EQ(srob, sref);
+
+            double nv = orient_2d(A, B, O);
+            if (((nv > 0) - (nv < 0)) != sref)
+                ++naive_wrong;
+        }
+        std::cout << "orient2d torture: naive determinant disagreed with the exact"
+                  << " sign on " << naive_wrong << " / " << n
+                  << " near-degenerate cases (robust predicate: 0 disagreements)\n";
+    }
+#endif
 }
 
 TEST(base_intersections, seg_seg_strict_intersection)

--- a/tests/tests_halfedgemesh.cpp
+++ b/tests/tests_halfedgemesh.cpp
@@ -13,8 +13,9 @@
 #include <topology/halfEdgeMeshRender.h>
 #include <topology/halfEdgeMeshQuality.h>
 #include <numbers>
-#include <random> 
+#include <random>
 #include <list>
+#include <cstdint>
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
@@ -164,6 +165,22 @@ inline auto add_random_points_grid(std::vector< std::array<T,2> > &coords, size_
     for(size_t i{}; i < n; i++)
     {
         coords.push_back(std::array<T,2>{static_cast<T>(uniform()), static_cast<T>(uniform())});
+    }
+}
+
+template <typename T>
+inline void add_random_points_grid_seeded(std::vector<std::array<T, 2>> &coords, size_t n, std::uint64_t seed, T x1 = 0)
+{
+    // Same platform-independent mapping as add_random_points_grid, but with an
+    // explicit seed so we can sweep many distinct "unlucky" clouds (#48).
+    std::mt19937_64 gen(seed);
+    auto uniform = [&]() {
+        const double u = static_cast<double>(gen() >> 11) * (1.0 / 9007199254740992.0);
+        return x1 + (1.0 - x1) * u;
+    };
+    for (size_t i{}; i < n; i++)
+    {
+        coords.push_back(std::array<T, 2>{static_cast<T>(uniform()), static_cast<T>(uniform())});
     }
 }
 
@@ -998,6 +1015,60 @@ TEST(halfEdgeMesh, delaunay2d_mesh_cloud)
             faces_mesh_actor<T,d>(faces_lst).Get(),
             boundary_mesh_actor<T,d>(getOrientedFacesBoundary(std::list< std::shared_ptr<HalfEdgeFace<T, d>> >(faces_lst))).Get(),
             coords_boundary);
+    }
+}
+
+TEST(halfEdgeMesh, delaunay2d_mesh_cloud_unlucky)
+{
+    using T = double;
+    using namespace gbs;
+
+    // Regression guard for #48: the previous cavity construction could collect a
+    // non-connected / non-star-shaped set of triangles and fan the new point to
+    // them, producing OVERLAPPING triangles -> meshed area > 1 (observed 1.00012
+    // on macOS for an "unlucky" random cloud). Because sum_area sums absolute
+    // triangle areas, any overlap inflates the total above the true domain area.
+    // A valid (overlap-free, gap-free) triangulation of the unit square always
+    // sums to exactly 1, on every platform. Sweep many distinct clouds to make
+    // it very likely to hit a degenerate cavity, plus one non-deterministic
+    // cloud (which is how the failure was first observed before being masked by
+    // making the seed fixed in commit b6db516).
+    auto coords_boundary = make_boundary2d_1<T>();
+    const T tol{1e-10};
+
+    for (std::uint64_t seed = 1; seed <= 50; ++seed)
+    {
+        std::vector<std::array<T, 2>> coords_inner;
+        add_random_points_grid_seeded(coords_inner, 400, seed);
+
+        auto faces_lst = delaunay2DBoyerWatson(coords_boundary, tol);
+        for (const auto &xy : coords_inner)
+        {
+            boyerWatson<T>(faces_lst, xy, tol);
+        }
+
+        auto area = getTriangle2dMeshArea(faces_lst);
+        CAPTURE(seed);
+        CAPTURE(area);
+        ASSERT_NEAR(area, 1.0, 1e-9);
+    }
+
+    {
+        std::random_device rd;
+        const std::uint64_t seed = (static_cast<std::uint64_t>(rd()) << 32) ^ rd();
+        std::vector<std::array<T, 2>> coords_inner;
+        add_random_points_grid_seeded(coords_inner, 600, seed);
+
+        auto faces_lst = delaunay2DBoyerWatson(coords_boundary, tol);
+        for (const auto &xy : coords_inner)
+        {
+            boyerWatson<T>(faces_lst, xy, tol);
+        }
+
+        auto area = getTriangle2dMeshArea(faces_lst);
+        CAPTURE(seed);
+        CAPTURE(area);
+        ASSERT_NEAR(area, 1.0, 1e-9);
     }
 }
 


### PR DESCRIPTION
## Summary

`boyerWatson` (`inc/topology/tessellations.h`) collected its cavity with a global `find_if` and an **asymmetric positive threshold** (`in_circle > tol`), on top of a **plain floating-point determinant** whose sign is not robust near degenerate configurations. That combination could produce a non-connected or non-star-shaped cavity; fanning the new point to its boundary then created **overlapping triangles**, inflating the meshed area (1.00012 vs 1.0) in a platform-dependent way (Linux/macOS divergence). The `assert(are_face_ccw(...))` guards would have caught it, but CI builds **Release (NDEBUG)** so they were compiled out and the invalid mesh survived silently.

This treats the **root cause**, not the symptom (it does not just re-determinise the cloud).

## Changes

**Exact-sign predicate — `inc/topology/robustPredicates.h` (new)**
- Templated port of Shewchuk's adaptive `orient2d`. A fast floating-point filter handles well-separated inputs; only near-degenerate ones fall back to the exact expansion arithmetic. The **sign is exact and identical on every platform/compiler**. Generic and reusable, per the architecture note in `CLAUDE.md`. FP contraction is disabled (scoped to the header) so the error-free transformations hold.

**Cavity construction — rewritten**
1. **Locate** the containing triangle(s) using exact `orient2d` (robust point-in-triangle).
2. **Grow by connectivity**: flood-fill across shared edges, adding a neighbour iff the point is strictly inside its circumcircle → a single connected region. Symmetric `> 0` threshold replaces the asymmetric `+ tol`.
3. **Runtime validation** (value check, *not* `assert`): the cavity boundary must be exactly one star-shaped loop w.r.t. the point. On any degeneracy, fall back to the minimal containing cavity, which is always star-shaped.

The star-shaped check is precisely the condition that each fan triangle is strictly CCW, so the re-triangulation **provably contains no overlapping triangle** and the meshed area equals the true domain area on every platform.

## Tests
- `tests_baseIntersections` → `orient2d_robust_exact`: a hand-crafted near-degenerate case where the naive determinant cancels to `0` but the exact sign is `+1`, plus a 100k-case torture vs a 128-bit integer reference. The naive determinant gets the sign **wrong on ~58% of the near-degenerate cases; the robust predicate on none.**
- `tests_halfedgemesh` → `delaunay2d_mesh_cloud_unlucky`: sweeps **50 distinct seeds** plus one **non-deterministic** cloud, asserting meshed area `== 1` (to `1e-9`) each time — reintroducing the non-deterministic coverage that commit `b6db516` had masked.

## Acceptance
- ✅ Meshed area `= 1.0` deterministically, including unlucky clouds, verified under **Release/NDEBUG** (asserts compiled out — validity rests on the runtime star-shaped check).
- ✅ No overlapping triangles; CCW invariant verified at runtime, not via `assert`.
- ✅ Full `tests_halfedgemesh` (20 cases) and `tests_baseIntersections` (5 cases) pass — no topology regression.

Refs #44. Closes #48.
