### PR TITLE
test: re-enable disabled tests fixed by recent work (#57)

### DIFF
--- a/tests/tests_bssbuild.cpp
+++ b/tests/tests_bssbuild.cpp
@@ -310,48 +310,66 @@ TEST(tests_bssbuild, loft_with_spine)
 
 }
 
+// DISABLED — blocked by #58 (NOT a silent re-disable; see below).
+//
+// Re-enabling this (#57) surfaced a *distinct* latent bug from the one #52 fixed:
+// lofting RATIONAL curves WITH A SPINE does not compile. `loft(list<...,true>*,
+// spine)` → `get_tg_from_spine<T,dim,rational>` stores the model-space spine
+// tangent `spine.value(v,1)` (array<T,dim>) into `D` of type array<T,dim+rational>
+// → "no viable overloaded '='". #52 only fixed the non-spine `loft_generic` return
+// type; the rational spine-tangent path was never generalized.
+//
+// This is a COMPILE-time failure, so a GTEST_SKIP cannot guard it — the body must
+// stay commented until #58 lands. The assertions below are the intended acceptance
+// check (rational SURFACE type + pass-through within 1e-6); re-enable verbatim then.
+//
 // TEST(tests_bssbuild, loft_rational_with_spine)
 // {
 //     size_t p = 2;
 //     std::vector<double> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
 //     gbs::points_vector_4d_d poles1 =
 //     {
-//         {0.,0.,0.,1.},
-//         {0.,1.,0.,1.1},
-//         {1.,1.,0.,1.},
-//         {1.,1.,0.0,1.},
-//         {2.,1.,0.0,1.},
-//         {3.,1.,0.,1.1},
-//         {0.,4.,0.,1.},
+//         {0.,0.,0.,1.}, {0.,1.,0.,1.1}, {1.,1.,0.,1.}, {1.,1.,0.0,1.},
+//         {2.,1.,0.0,1.}, {3.,1.,0.,1.1}, {0.,4.,0.,1.},
 //     };
 //     gbs::points_vector_4d_d poles2 =
 //     {
-//         {0.,0.,1.,1.},
-//         {0.,1.,1.3,1.},
-//         {1.,1.,1.2,1.},
-//         {1.,2.,1.4,1.},
-//         {2.,1.,1.3,1.2},
-//         {3.,1.,1.1,1.},
-//         {2.,4.,1.,1.},
+//         {0.,0.,1.,1.}, {0.,1.,1.3,1.}, {1.,1.,1.2,1.}, {1.,2.,1.4,1.},
+//         {2.,1.,1.3,1.2}, {3.,1.,1.1,1.}, {2.,4.,1.,1.},
 //     };
 //     gbs::points_vector_4d_d poles3 =
 //     {
-//         {0.,0.,2.,1.},
-//         {0.,1.,2.2,1.},
-//         {1.,1.,2.2,1.2},
-//         {1.,2.,2.3,1.},
-//         {2.,1.,2.1,1.},
-//         {3.,1.,2.,1.},
-//         {1.,4.,2.,1.},
+//         {0.,0.,2.,1.}, {0.,1.,2.2,1.}, {1.,1.,2.2,1.2}, {1.,2.,2.3,1.},
+//         {2.,1.,2.1,1.}, {3.,1.,2.,1.}, {1.,4.,2.,1.},
 //     };
 //     gbs::BSCurveRational3d_d c1(poles1,k,p);
 //     gbs::BSCurveRational3d_d c2(poles2,k,p);
 //     gbs::BSCurveRational3d_d c3(poles3,k,p);
 //     gbs::BSCurve3d_d sp({{1.5,1.5,0.},{1.5,1.5,3.}},{0.,0.,1.,1.},1);
-
+//
 //     std::list<gbs::BSCurveGeneral<double,3,true>*> bs_lst = {&c1,&c2,&c3};
-//     auto s = gbs::loft( bs_lst , sp);
-//     gbs::plot(s,c1,c2,c3);
+//     auto s = gbs::loft( bs_lst , sp);  // <-- does not compile, blocked by #58
+//
+//     static_assert(
+//         std::is_same_v<decltype(s), gbs::BSSurfaceRational<double,3>>,
+//         "loft of rational curves must yield a BSSurfaceRational");
+//
+//     auto [u_min, u_max, v_min, v_max] = s.bounds();
+//     for (auto u_ : gbs::make_range(k.front(), k.back(), 50))
+//     {
+//         ASSERT_LT( gbs::distance( s(u_, v_min), c1(u_) ), 1e-6 );
+//         ASSERT_LT( gbs::distance( s(u_, v_max), c3(u_) ), 1e-6 );
+//     }
+//     std::vector<const gbs::BSCurveRational3d_d *> crv_lst{&c1, &c2, &c3};
+//     for (const auto *crv : crv_lst)
+//         for (auto u_ : gbs::make_range(k.front(), k.back(), 20))
+//         {
+//             auto [u_s, v_s, d] = gbs::extrema_surf_pnt(s, (*crv)(u_), 1e-7);
+//             ASSERT_LT( d, 1e-6 );
+//         }
+//
+//     if(PLOT_ON)
+//         gbs::plot(s,c1,c2,c3,sp);
 // }
 
 TEST(tests_bssbuild, gordon_bss)
@@ -437,11 +455,10 @@ TEST(tests_bssbuild, gordon_bss)
 
 TEST(tests_bssbuild,gordon_foils)
 {
-    GTEST_SKIP() << "Skipping this test for now.";
     using namespace gbs;
     using T = double;
 
-    
+
     std::string dir = get_directory(__FILE__);
 
     auto crv1_2d = bscurve_approx_from_points<T,2>(dir +"/in/e1098.dat",5,KnotsCalcMode::CHORD_LENGTH,1);
@@ -464,13 +481,35 @@ TEST(tests_bssbuild,gordon_foils)
     // auto Lu = loft<T,3,false>(u_crv_lst.begin(),u_crv_lst.end(),{0., 0.5, 1.},2);
     auto Lu = loft(u_crv_lst,{0., 0.5, 1.},2);
 
-    
+
     auto g1 = interpolate(points_vector<T,3>{crv1.begin(),crv2.begin(), crv3.begin()},{0.,0.5,1.},2);
-    auto ule1 = max_curvature_pos(crv1, 1e-6)[0];
-    auto ule2 = max_curvature_pos(crv2, 1e-6)[0];
-    auto ule3 = max_curvature_pos(crv3, 1e-6)[0];
     auto g2 = interpolate(points_vector<T,3>{crv1(0.5),crv2(0.5), crv3(0.5)},{0.,0.5,1.},2);
     auto g3 = interpolate(points_vector<T,3>{crv1.end(),crv2.end(), crv3.end()},{0.,0.5,1.},2);
+
+    // The v-direction interpolations (#34) pass through their defining points at
+    // the prescribed parameters {0, 0.5, 1}.
+    ASSERT_LT( gbs::distance( g1(0.0), crv1.begin() ), 1e-6 );
+    ASSERT_LT( gbs::distance( g1(0.5), crv2.begin() ), 1e-6 );
+    ASSERT_LT( gbs::distance( g1(1.0), crv3.begin() ), 1e-6 );
+    ASSERT_LT( gbs::distance( g2(0.0), crv1(0.5) ), 1e-6 );
+    ASSERT_LT( gbs::distance( g2(0.5), crv2(0.5) ), 1e-6 );
+    ASSERT_LT( gbs::distance( g2(1.0), crv3(0.5) ), 1e-6 );
+    ASSERT_LT( gbs::distance( g3(0.0), crv1.end() ), 1e-6 );
+    ASSERT_LT( gbs::distance( g3(0.5), crv2.end() ), 1e-6 );
+    ASSERT_LT( gbs::distance( g3(1.0), crv3.end() ), 1e-6 );
+
+    // Each foil lies on the lofted surface (#40). Project sampled foil points onto
+    // Lu: robust to the loft's internal u/v parametrization.
+    auto [lu_umin, lu_umax, lu_vmin, lu_vmax] = Lu.bounds();
+    for (const auto *crv : {&crv1, &crv2, &crv3})
+    {
+        auto [c_umin, c_umax] = crv->bounds();
+        for (auto u_ : gbs::make_range(c_umin, c_umax, 20))
+        {
+            auto [u_s, v_s, d] = gbs::extrema_surf_pnt(Lu, (*crv)(u_), 1e-7);
+            ASSERT_LT( d, 1e-6 );
+        }
+    }
 
     if(PLOT_ON)
         gbs::plot( crv1, crv2, crv3, g1, g2, g3, Lu );

--- a/tests/tests_knotsfunctions.cpp
+++ b/tests/tests_knotsfunctions.cpp
@@ -342,7 +342,13 @@ TEST(tests_knotsfunctions, increase_deg_Pieg94)
 
 TEST(tests_knotsfunctions, remove_knot_algo)
 {
-    GTEST_SKIP() << "Skipping this test for now.";
+    // BLOCKED by #59 (NOT a silent re-disable): re-enabling this surfaced a real
+    // library bug — remove_knot(u,p,num,U,Pw,tol) under-removes a freshly inserted
+    // knot (returns 1 for num=2) and the insert+remove round-trip does not restore
+    // the original U/Pw. The basis_function support checks below (#42/#49) DO pass;
+    // only the removal count / round-trip fails. Remove this skip once #59 lands —
+    // the assertions are the intended A5.8 acceptance check for #43.
+    GTEST_SKIP() << "blocked by #59 (remove_knot num>1 under-removes)";
     using namespace gbs;
     using T = double;
     const size_t dim{3};
@@ -362,87 +368,38 @@ TEST(tests_knotsfunctions, remove_knot_algo)
     };
     size_t p = 3;
 
+    // Pre-insertion state: an exact insert+remove round-trip of a freshly inserted
+    // knot must restore U and Pw (NURBS Book A5.8, still "to verify" in audit #43).
+    const std::vector<T> U0 = U;
+    const std::vector<std::array<T,dim>> Pw0 = Pw;
+
     size_t num{2};
     T u{1.5};
     for(size_t i{}; i<num; i++)
         insert_knot(u, p, U, Pw);
 
+    // After insertion u has multiplicity num: the only basis functions non-zero at u
+    // are those over the support window [first, last] (A2.1 find_span/basis, #42/#49).
     auto r = std::distance( U.begin(), std::ranges::upper_bound(U, u) ) -1;
     auto s = multiplicity(u,U);
-    auto m = U.size();
     auto n = Pw.size();
     auto first = r-p;
     auto last  = r-s;
+    for(size_t i{}; i < first; i++)
+        ASSERT_DOUBLE_EQ(basis_function(u, i, p, 0, U), 0.);
+    for(size_t i= last+1; i < n; i++)
+        ASSERT_DOUBLE_EQ(basis_function(u, i, p, 0, U), 0.);
 
+    // Remove the inserted knot num times through the audited A5.8 implementation.
+    auto removed = remove_knot(u, p, num, U, Pw, tol);
 
-    size_t t{0};
-    std::list<std::array<T,dim>> Pi;
-    std::list<std::array<T,dim>> Pj;
-    for( ; t < num; t++)
-    {
-        for(size_t i{}; i < first; i++)
-            ASSERT_DOUBLE_EQ(basis_function(u, i, p, 0, U), 0.);
-        for(size_t i= last+1; i < n; i++)
-            ASSERT_DOUBLE_EQ(basis_function(u, i, p, 0, U), 0.);
-        auto i{first};
-        auto j{last};
-        Pi = {Pw[first-1]};
-        Pj = {Pw[last+1]};
-        while(j>i+t)
-        {
-            auto ai = (u-U[i  ])/(U[i+p+1+t]-U[i  ]);
-            auto aj = (u-U[j-t])/(U[j+p+1  ]-U[j-t]);
-
-            Pi.push_back( (Pw[i]-(1-ai)*Pi.back())/ ai);
-            Pj.push_front((Pw[j]-  aj*Pj.front())/ (1-aj));
-            i++;
-            j--;
-        }
-        bool remove_flag=false;
-        if(j<i+t)
-        {
-            if(distance(Pi.back(), Pj.front())<tol)
-            {
-                remove_flag=true;
-                Pj.pop_front();
-            }
-        }
-        else
-        {
-            auto ai = (u-U[i  ])/(U[i+p+1+t]-U[i  ]);
-            if(distance(Pw[i], ai*Pi.back()+(1-ai)*Pj.front())<tol)
-            {
-                remove_flag=true;
-                Pj.pop_front();
-                Pi.pop_back();
-            }
-        }
-
-        if(!remove_flag)
-        {
-            break;
-        }
-        else{
-            auto i{first};
-            auto j{last};
-
-        }
-        first--; last++;
-
-    }
-    if(t>0){
-        auto Pw_beg=Pw.begin();
-        std::vector<std::array<T,dim>> head{Pw_beg,std::next(Pw_beg,first)};
-        std::vector<std::array<T,dim>> tail{std::next(Pw_beg,last+1), Pw.end()};
-        Pw = std::move(head);
-        Pw.insert(Pw.end(), Pi.begin(), Pi.end());
-        Pw.insert(Pw.end(), Pj.begin(), Pj.end());
-        Pw.insert(Pw.end(), tail.begin(), tail.end());
-
-        U.erase(std::next(U.begin(),r-t+1), std::next(U.begin(),r+1));
-    }
-
+    // The round-trip restores the original knot vector and poles exactly.
+    ASSERT_EQ(removed, num);
     ASSERT_EQ(U.size()-p-1, Pw.size());
+    ASSERT_EQ(U, U0);
+    ASSERT_EQ(Pw.size(), Pw0.size());
+    for(size_t i{}; i<Pw0.size(); ++i)
+        ASSERT_LT( gbs::distance(Pw[i], Pw0[i]), tol );
 }
 
 TEST(tests_knotsfunctions, remove_knot)


### PR DESCRIPTION
Re-enable the disabled tests that recent correctness work plausibly fixed, with
real value assertions, and file focused issues for the two that turned out to be
blocked by still-latent bugs. Touches `tests/` only (disjoint from #48 and #47).

Closes #57. Tracked under epic #44.

## Results

| Test | Outcome |
|------|---------|
| `tests_bssbuild.gordon_foils` | ✅ **enabled + green** with assertions |
| `tests_knotsfunctions.remove_knot_algo` | ⏭️ blocked by **#59** (real `remove_knot` bug), documented skip |
| `tests_bssbuild.loft_rational_with_spine` | 💬 blocked by **#58** (rational+spine loft does not compile), documented comment |

Build/run (the two affected targets), both green:
- `tests_bssbuild`: 15 cases, 0 failed.
- `tests_knotsfunctions`: 14 cases, 0 failed.

## gordon_foils — enabled, green

Dropped the `GTEST_SKIP` and added value assertions to what previously only
`plot`ed:
- the v-direction interpolations `g1/g2/g3` pass through their defining points at
  the prescribed parameters `{0, 0.5, 1}` (#34);
- each airfoil section lies on the lofted surface `Lu`, verified by projecting
  sampled foil points onto `Lu` (`extrema_surf_pnt`, distance `< 1e-6`) — robust
  to the loft's internal u/v parametrization (#40).

Confirmed `tests/in/{e1098,e817,e186}.dat` exist. Also dropped three unused
`max_curvature_pos` locals.

## remove_knot_algo — surfaced a real bug (#59)

Re-enabling replaced the hand-rolled inline A5.8 copy with a round-trip against the
audited library `remove_knot`, keeping the `basis_function` support checks (A2.1
find_span/basis, #42/#49, which **pass**). This exposed a genuine library defect:
`remove_knot(u, p, num, U, Pw, tol)` under-removes a freshly inserted knot —
returns `1` for `num = 2` and does not restore the original `U`/`Pw` (pole/knot
count desync 11 vs 10). Filed as **#59** with a minimal repro and root-cause
analysis. The test keeps a `GTEST_SKIP` with a comment pointing to #59 (a runtime
failure, so the skip is legitimate and documented — not silent); the round-trip
assertions are the intended acceptance once #59 lands and double as the A5.8
transcription confirmation for audit #43.

## loft_rational_with_spine — surfaced a distinct bug (#58)

This is a *different* defect from the one #52 fixed (#52 fixed the non-spine
`loft_generic` return type). Lofting **rational** curves **with a spine** does not
compile: `get_tg_from_spine<T,dim,rational>` stores the model-space spine tangent
`spine.value(v,1)` (`array<T,dim>`) into `D` of type `array<T,dim+rational>`. Filed
as **#58**. Left commented with a pointer to #58 and the intended assertions
(rational-surface type + pass-through within `1e-6`), since a compile-time failure
cannot be guarded by `GTEST_SKIP`.

## Out of scope (left as documented in #57)

- gbs-occt `tests_curvesbuild` skips → tracked by #47.
- `tests_knotsfunctions.reparam4` (half-finished, commented) → left as-is.
- `tests_topo_halfEdgeMeshData` two commented `TEST_F` → inconsistent by
  construction, unrelated to the bspline fixes.
