### PR TITLE
fix(knotsfunctions): faithful A5.8 transcription for remove_knot (num>1 under-removes)

### DIFF
--- a/gbs/knotsfunctions.ixx
+++ b/gbs/knotsfunctions.ixx
@@ -553,100 +553,131 @@
     template <typename T, size_t dim>
     auto remove_knot(T u, size_t p, size_t num, std::vector<T> &U, std::vector<std::array<T, dim>> &Pw, T tol)
     {
+        // Faithful transcription of NURBS Book A5.8 (RemoveCurveKnot, p.185).
+        // A single interleaved temp[] buffer is carried across the `t` removal
+        // passes: each pass reads the partially-removed state, the deviation
+        // (tolerance) test decides whether the pass is accepted, and an accepted
+        // pass is committed in place into Pw before `first`/`last` close in. This
+        // replaces the previous Pi/Pj implementation, which restarted from the raw
+        // Pw on every pass (so pass t>0 read stale poles and under-removed) and
+        // advanced first/last even on a failing pass (desyncing the rebuild).
+
         // Determine the knot interval that contains u
         auto r = std::distance(U.begin(), std::ranges::upper_bound(U, u)) - 1;
-        // if u is not a knot
-        if(std::abs(U[r]-u)>knot_eps<T>)
+        // if u is not an internal knot, there is nothing to remove
+        if (std::abs(U[r] - u) > knot_eps<T> || r == 0 || r == static_cast<decltype(r)>(U.size()))
         {
-            // return false;
+            return size_t{0};
         }
+        if (num < 1)
+        {
+            return size_t{0};
+        }
+
         // Find the multiplicity of the knot u
         auto s = multiplicity(u, U);
-        auto m = U.size();
-        auto n = Pw.size();
-        
-        // Determine the first and last affected control points
-        auto first = r - p;
-        auto last = r - s;
-        
-        size_t t{0};
-        std::list<std::array<T, dim>> Pi;
-        std::list<std::array<T, dim>> Pj;
-        
-        // Try to remove the knot u num times
-        for (; t < num; t++)
-        {
-            auto i{first};
-            auto j{last};
-            
-            // Initialize lists of control points Pi and Pj
-            Pi = {Pw[first - 1]};
-            Pj = {Pw[last + 1]};
-            
-            while (j > i + t)
-            {
-                // Compute blending factors
-                auto ai = (u - U[i]) / (U[i + p + 1 + t] - U[i]);
-                auto aj = (u - U[j - t]) / (U[j + p + 1] - U[j - t]);
 
-                // Compute new control points
-                Pi.push_back((Pw[i] - (1 - ai) * Pi.back()) / ai);
-                Pj.push_front((Pw[j] - aj * Pj.front()) / (1 - aj));
-                i++;
-                j--;
-            }
-            
+        int m = static_cast<int>(U.size());
+        int ord = static_cast<int>(p) + 1;
+        int fout = (2 * r - s - static_cast<int>(p)) / 2; // first control point out
+        int last = r - s;
+        int first = r - static_cast<int>(p);
+
+        std::vector<std::array<T, dim>> temp(2 * p + 1);
+
+        T alfi, alfj;
+        int i, j, k, ii, jj, off;
+
+        // Try to remove the knot u up to num times (this loop is Eq. 5.28)
+        int t;
+        for (t = 0; t < static_cast<int>(num); ++t)
+        {
+            off = first - 1; // index difference between temp and Pw
+            temp[0] = Pw[off];
+            temp[last + 1 - off] = Pw[last + 1];
+            i = first;
+            j = last;
+            ii = 1;
+            jj = last - off;
             bool remove_flag = false;
-            if (j < i + t)
+
+            // Compute the candidate control points for this removal pass
+            while (j - i > t)
             {
-                // If the knot can be removed, update Pi and Pj
-                auto d = distance(Pi.back(), Pj.front());
-                if (d < tol)
-                {
+                alfi = (u - U[i]) / (U[i + ord + t] - U[i]);
+                alfj = (u - U[j - t]) / (U[j + ord] - U[j - t]);
+                temp[ii] = (Pw[i] - (1.0 - alfi) * temp[ii - 1]) / alfi;
+                temp[jj] = (Pw[j] - alfj * temp[jj + 1]) / (1.0 - alfj);
+                ++i;
+                ++ii;
+                --j;
+                --jj;
+            }
+
+            // Check whether the knot is removable within tolerance
+            if (j - i < t)
+            {
+                if (distance(temp[ii - 1], temp[jj + 1]) <= tol)
                     remove_flag = true;
-                    Pj.pop_front();
-                }
             }
             else
             {
-                // Check if knot removal is possible
-                auto ai = (u - U[i]) / (U[i + p + 1 + t] - U[i]);
-                auto d = distance(Pw[i], ai * Pi.back() + (1 - ai) * Pj.front());
-                if (d < tol)
-                {
+                alfi = (u - U[i]) / (U[i + ord + t] - U[i]);
+                if (distance(Pw[i], alfi * temp[ii + t + 1] + (1.0 - alfi) * temp[ii - 1]) <= tol)
                     remove_flag = true;
-                    Pj.pop_front();
-                    Pi.pop_back();
-                }
             }
-            
-            first--;
-            last++;
 
             if (!remove_flag)
             {
-                break;
+                break; // cannot remove any further
             }
 
+            // Successful removal: commit the new control points in place
+            i = first;
+            j = last;
+            while (j - i > t)
+            {
+                Pw[i] = temp[i - off];
+                Pw[j] = temp[j - off];
+                ++i;
+                --j;
+            }
+
+            --first;
+            ++last;
         }
-        if (t > 0)
+
+        if (t == 0)
         {
-            // If at least one knot has been removed, update the control points Pw
-            auto Pw_beg = Pw.begin();
-            std::vector<std::array<T, dim>> head{Pw_beg, std::next(Pw_beg, first)};
-            std::vector<std::array<T, dim>> tail{std::next(Pw_beg, last + 1), Pw.end()};
-            Pw = std::move(head);
-            Pw.insert(Pw.end(), Pi.begin(), Pi.end());
-            Pw.insert(Pw.end(), Pj.begin(), Pj.end());
-            Pw.insert(Pw.end(), tail.begin(), tail.end());
-
-            U.erase(std::next(U.begin(),r-t+1), std::next(U.begin(),r+1));
-
-            assert(U.size()-p-1==Pw.size());
+            return size_t{0};
         }
+
+        // Shift the knots down to drop the t removed occurrences
+        for (k = r + 1; k < m; ++k)
+            U[k - t] = U[k];
+
+        // Shift the poles, overwriting the Pj .. Pi gap left by the removal
+        j = fout;
+        i = j;
+        for (k = 1; k < t; ++k)
+        {
+            if ((k % 2) == 1)
+                ++i;
+            else
+                --j;
+        }
+        for (k = i + 1; k < static_cast<int>(Pw.size()); ++k)
+        {
+            Pw[j++] = Pw[k];
+        }
+
+        Pw.resize(Pw.size() - t);
+        U.resize(U.size() - t);
+
+        assert(U.size() - p - 1 == Pw.size());
 
         // Return the number of times the knot was actually removed
-        return t;
+        return static_cast<size_t>(t);
     }
     /**
      * @brief This function removes a knot from a B-spline.

--- a/tests/tests_knotsfunctions.cpp
+++ b/tests/tests_knotsfunctions.cpp
@@ -342,13 +342,10 @@ TEST(tests_knotsfunctions, increase_deg_Pieg94)
 
 TEST(tests_knotsfunctions, remove_knot_algo)
 {
-    // BLOCKED by #59 (NOT a silent re-disable): re-enabling this surfaced a real
-    // library bug — remove_knot(u,p,num,U,Pw,tol) under-removes a freshly inserted
-    // knot (returns 1 for num=2) and the insert+remove round-trip does not restore
-    // the original U/Pw. The basis_function support checks below (#42/#49) DO pass;
-    // only the removal count / round-trip fails. Remove this skip once #59 lands —
-    // the assertions are the intended A5.8 acceptance check for #43.
-    GTEST_SKIP() << "blocked by #59 (remove_knot num>1 under-removes)";
+    // Regression for #59 (A5.8 RemoveCurveKnot): removing a freshly inserted knot
+    // num times must return num and the insert+remove round-trip must restore the
+    // original U/Pw to ~machine epsilon. Re-enabled once #59 landed; also serves as
+    // the A5.8 transcription acceptance check for audit #43.
     using namespace gbs;
     using T = double;
     const size_t dim{3};


### PR DESCRIPTION
## Summary

`remove_knot(u, p, num, U, Pw, tol)` (`gbs/knotsfunctions.ixx`, NURBS Book A5.8
`RemoveCurveKnot`) **under-removed** when taking a knot down to a low/zero remaining
multiplicity: removing a freshly *inserted* knot `num` times returned `1` instead of
`num`, and the `insert ×num` / `remove ×num` round-trip did **not** restore the
original `U`/`Pw` (it even produced an inconsistent `U.size()-p-1 == 10` with
`Pw.size() == 11`).

## Root cause

The previous `Pi`/`Pj` implementation reinitialised the working poles
`Pi = {Pw[first-1]}`, `Pj = {Pw[last+1]}` from the **raw** `Pw` at the start of *every*
`t` pass and only wrote the result back once, after the loop. Pass `t>0` therefore read
stale (un-removed) poles, so the `t`-offset removability test reported the knot as
non-removable and broke at `t = 1`. It also applied `first--; last++;` *before* the
remove-flag check, desyncing `first`/`last` from the actually-removed count on a failing
pass and corrupting the `head + Pi + Pj + tail` rebuild (the 11-vs-10 mismatch).

## Fix

Rewrite the overload as a **faithful transcription of A5.8 (RemoveCurveKnot)**:
- a single interleaved `temp[]` buffer carried across the `t` passes, so each pass
  operates on the partially-removed state;
- the per-pass deviation (tolerance) test that decides whether the pass is accepted;
- the new control points committed **in place** into `Pw` only on an accepted pass;
- `first`/`last` advanced **only after** a successful pass.

This mirrors the existing tolerance-free A5.8 transcription in the same file, with the
deviation test added back.

## Tests

- Re-enables `tests_knotsfunctions.remove_knot_algo` (skipped in #57 with a pointer to
  #59). It now asserts the A5.8 acceptance: `removed == num`, `U.size()-p-1 == Pw.size()`,
  `U == U0`, and every pole restored to `< tol` of `Pw0` after the insert/remove round-trip.
- The sibling `tests_knotsfunctions.remove_knot` (multiplicity 4 → 2, plus a 1000-sample
  geometric-preservation check) still passes.
- `tests_knotsfunctions`: 14/14 cases, 0 skipped. `tests_bscurve` (consumer via
  `BSCurve::removeKnot`): 15/15.

Closes #59. Refs audit #43 (closes the A5.8 deviation) and epic #44.
