### PR TITLE
fix(bssbuild): rational loft with spine compiles and interpolates (#58)

### DIFF
--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -97,6 +97,48 @@ namespace gbs
         return get_degree(max_deg_curve);
     }
 
+    /**
+     * @brief Lift a model-space spine tangent into pole (homogeneous when rational) space.
+     *
+     * The spine is non-rational, so `spine.value(v,1)` is a model-space tangent
+     * `V` (dim components). For a rational loft the surface control net lives in
+     * homogeneous space, so the v-tangent the Hermite solve interpolates must be
+     * homogeneous too.
+     *
+     * Moving a pole along the spine direction is a CONSTANT-weight model-space
+     * displacement: with the homogeneous pole `P^w = (w*P, w)`,
+     *     P^w(t) = ( w*(P + t*V), w )  =>  dP^w/dt = ( w*V, 0 ).
+     * Hence the spatial part is scaled by the pole weight `w` and the weight
+     * component is null (the spine carries no weight variation) — the 4th
+     * component is zero by derivation, not to silence the compiler.
+     *
+     * For the non-rational case this is just `s * V` (no weight component), which
+     * reproduces the previous behaviour bit-for-bit.
+     *
+     * @param s         scalar magnitude (chord-length / spine-distance scaling).
+     * @param tg_model  model-space spine tangent `V` (dim components).
+     * @param pole      the homogeneous (or plain) pole the tangent is attached to.
+     */
+    template <typename T, size_t dim, bool rational>
+    inline auto spine_tangent_to_pole(T s, const std::array<T, dim> &tg_model, const point<T, dim + rational> &pole)
+        -> point<T, dim + rational>
+    {
+        point<T, dim + rational> r;
+        if constexpr (rational)
+        {
+            const T w = pole.back();
+            for (size_t i = 0; i < dim; ++i)
+                r[i] = s * w * tg_model[i];
+            r[dim] = T{0}; // constant weight along the spine direction
+        }
+        else
+        {
+            for (size_t i = 0; i < dim; ++i)
+                r[i] = s * tg_model[i];
+        }
+        return r;
+    }
+
     template <typename T, size_t dim, bool rational,typename Container>
     auto get_tg_from_spine(const std::vector<points_vector<T, dim + rational>> &poles_v_lst, const BSCurve<T, dim> &spine,const Container &bs_lst_cpy)
     {
@@ -113,7 +155,7 @@ namespace gbs
                     return extrema_curve_curve<T,dim>(spine,profile_,1e-6)[0];
                 }
         );
-        // compute spine distances
+        // compute spine distances (model space — the spine is non-rational)
         std::vector<T> d(v_spine.size() - 1);
         std::transform(
             GBS_PAR_EXEC
@@ -124,8 +166,9 @@ namespace gbs
             [&](const auto &v2_, const auto &v1_) {
                 return norm(spine.value(v2_) - spine.value(v1_));
             });
-        // compute spine tg
-        std::vector<std::array<T,dim+rational>> D(v_spine.size());
+        // compute spine tangents in MODEL space (dim components); they are lifted
+        // into homogeneous pole space per-pole below (weight depends on the pole).
+        std::vector<std::array<T,dim>> D(v_spine.size());
         std::transform(
             GBS_PAR_EXEC
             v_spine.begin(),
@@ -142,13 +185,24 @@ namespace gbs
             [&](const auto &pts)
             {
                 auto n_poles_v = pts.size();
+                // Project the column's poles to model space so the chord-length
+                // scaling is taken consistently with the model-space spine
+                // distances `d` (for the rational case `pts` are homogeneous, so a
+                // raw norm would mix in the weights — exactly the #58 inconsistency).
+                points_vector<T, dim> pm(n_poles_v);
+                std::transform(pts.begin(), pts.end(), pm.begin(),
+                               [](const auto &p) { return weight_projected_pole<T, dim, rational>(p); });
+
                 points_vector<T,dim + rational> tg_i(n_poles_v);
-                tg_i[0] = norm(pts[1]-pts[0])*D[0]/d[0];
+                tg_i[0] = spine_tangent_to_pole<T, dim, rational>(
+                    norm(pm[1] - pm[0]) / d[0], D[0], pts[0]);
                 for(auto k = 1 ; k < n_poles_v - 1; k++)
                 {
-                    tg_i[k] = ( norm(pts[k+1]-pts[k]) +  norm(pts[k]-pts[k-1]) ) * D[k] / (d[k]+d[k-1]);
+                    tg_i[k] = spine_tangent_to_pole<T, dim, rational>(
+                        (norm(pm[k+1] - pm[k]) + norm(pm[k] - pm[k-1])) / (d[k] + d[k-1]), D[k], pts[k]);
                 }
-                tg_i[n_poles_v-1] = norm(pts[n_poles_v-1]-pts[n_poles_v-2])*D[n_poles_v-1]/d[n_poles_v-2];
+                tg_i[n_poles_v-1] = spine_tangent_to_pole<T, dim, rational>(
+                    norm(pm[n_poles_v-1] - pm[n_poles_v-2]) / d[n_poles_v-2], D[n_poles_v-1], pts[n_poles_v-1]);
                 return tg_i;
             });
             return tg_v_lst;

--- a/tests/tests_bssbuild.cpp
+++ b/tests/tests_bssbuild.cpp
@@ -310,67 +310,63 @@ TEST(tests_bssbuild, loft_with_spine)
 
 }
 
-// DISABLED — blocked by #58 (NOT a silent re-disable; see below).
-//
-// Re-enabling this (#57) surfaced a *distinct* latent bug from the one #52 fixed:
-// lofting RATIONAL curves WITH A SPINE does not compile. `loft(list<...,true>*,
-// spine)` → `get_tg_from_spine<T,dim,rational>` stores the model-space spine
-// tangent `spine.value(v,1)` (array<T,dim>) into `D` of type array<T,dim+rational>
-// → "no viable overloaded '='". #52 only fixed the non-spine `loft_generic` return
-// type; the rational spine-tangent path was never generalized.
-//
-// This is a COMPILE-time failure, so a GTEST_SKIP cannot guard it — the body must
-// stay commented until #58 lands. The assertions below are the intended acceptance
-// check (rational SURFACE type + pass-through within 1e-6); re-enable verbatim then.
-//
-// TEST(tests_bssbuild, loft_rational_with_spine)
-// {
-//     size_t p = 2;
-//     std::vector<double> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
-//     gbs::points_vector_4d_d poles1 =
-//     {
-//         {0.,0.,0.,1.}, {0.,1.,0.,1.1}, {1.,1.,0.,1.}, {1.,1.,0.0,1.},
-//         {2.,1.,0.0,1.}, {3.,1.,0.,1.1}, {0.,4.,0.,1.},
-//     };
-//     gbs::points_vector_4d_d poles2 =
-//     {
-//         {0.,0.,1.,1.}, {0.,1.,1.3,1.}, {1.,1.,1.2,1.}, {1.,2.,1.4,1.},
-//         {2.,1.,1.3,1.2}, {3.,1.,1.1,1.}, {2.,4.,1.,1.},
-//     };
-//     gbs::points_vector_4d_d poles3 =
-//     {
-//         {0.,0.,2.,1.}, {0.,1.,2.2,1.}, {1.,1.,2.2,1.2}, {1.,2.,2.3,1.},
-//         {2.,1.,2.1,1.}, {3.,1.,2.,1.}, {1.,4.,2.,1.},
-//     };
-//     gbs::BSCurveRational3d_d c1(poles1,k,p);
-//     gbs::BSCurveRational3d_d c2(poles2,k,p);
-//     gbs::BSCurveRational3d_d c3(poles3,k,p);
-//     gbs::BSCurve3d_d sp({{1.5,1.5,0.},{1.5,1.5,3.}},{0.,0.,1.,1.},1);
-//
-//     std::list<gbs::BSCurveGeneral<double,3,true>*> bs_lst = {&c1,&c2,&c3};
-//     auto s = gbs::loft( bs_lst , sp);  // <-- does not compile, blocked by #58
-//
-//     static_assert(
-//         std::is_same_v<decltype(s), gbs::BSSurfaceRational<double,3>>,
-//         "loft of rational curves must yield a BSSurfaceRational");
-//
-//     auto [u_min, u_max, v_min, v_max] = s.bounds();
-//     for (auto u_ : gbs::make_range(k.front(), k.back(), 50))
-//     {
-//         ASSERT_LT( gbs::distance( s(u_, v_min), c1(u_) ), 1e-6 );
-//         ASSERT_LT( gbs::distance( s(u_, v_max), c3(u_) ), 1e-6 );
-//     }
-//     std::vector<const gbs::BSCurveRational3d_d *> crv_lst{&c1, &c2, &c3};
-//     for (const auto *crv : crv_lst)
-//         for (auto u_ : gbs::make_range(k.front(), k.back(), 20))
-//         {
-//             auto [u_s, v_s, d] = gbs::extrema_surf_pnt(s, (*crv)(u_), 1e-7);
-//             ASSERT_LT( d, 1e-6 );
-//         }
-//
-//     if(PLOT_ON)
-//         gbs::plot(s,c1,c2,c3,sp);
-// }
+// Re-enabled by #58: lofting RATIONAL curves WITH A SPINE now compiles and works.
+// The spine-tangent path (`get_tg_from_spine`) now lifts the model-space spine
+// tangent into homogeneous pole space per pole (spatial part scaled by the pole
+// weight, null weight component — constant weight along the spine). Acceptance:
+// rational SURFACE type + pass-through within 1e-6.
+TEST(tests_bssbuild, loft_rational_with_spine)
+{
+    size_t p = 2;
+    std::vector<double> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
+    gbs::points_vector_4d_d poles1 =
+    {
+        {0.,0.,0.,1.}, {0.,1.,0.,1.1}, {1.,1.,0.,1.}, {1.,1.,0.0,1.},
+        {2.,1.,0.0,1.}, {3.,1.,0.,1.1}, {0.,4.,0.,1.},
+    };
+    gbs::points_vector_4d_d poles2 =
+    {
+        {0.,0.,1.,1.}, {0.,1.,1.3,1.}, {1.,1.,1.2,1.}, {1.,2.,1.4,1.},
+        {2.,1.,1.3,1.2}, {3.,1.,1.1,1.}, {2.,4.,1.,1.},
+    };
+    gbs::points_vector_4d_d poles3 =
+    {
+        {0.,0.,2.,1.}, {0.,1.,2.2,1.}, {1.,1.,2.2,1.2}, {1.,2.,2.3,1.},
+        {2.,1.,2.1,1.}, {3.,1.,2.,1.}, {1.,4.,2.,1.},
+    };
+    gbs::BSCurveRational3d_d c1(poles1,k,p);
+    gbs::BSCurveRational3d_d c2(poles2,k,p);
+    gbs::BSCurveRational3d_d c3(poles3,k,p);
+    gbs::BSCurve3d_d sp({{1.5,1.5,0.},{1.5,1.5,3.}},{0.,0.,1.,1.},1);
+
+    std::list<gbs::BSCurveGeneral<double,3,true>*> bs_lst = {&c1,&c2,&c3};
+    auto s = gbs::loft( bs_lst , sp);
+
+    static_assert(
+        std::is_same_v<decltype(s), gbs::BSSurfaceRational<double,3>>,
+        "loft of rational curves must yield a BSSurfaceRational");
+
+    auto [u_min, u_max, v_min, v_max] = s.bounds();
+    // Boundary sections are reproduced exactly at v_min / v_max: the homogeneous
+    // pole net at the first / last v-row equals c1 / c3, so the projected rational
+    // surface matches each curve to machine precision along the whole span.
+    for (auto u_ : gbs::make_range(k.front(), k.back(), 50))
+    {
+        ASSERT_LT( gbs::distance( s(u_, v_min), c1(u_) ), 1e-6 );
+        ASSERT_LT( gbs::distance( s(u_, v_max), c3(u_) ), 1e-6 );
+    }
+    // Interior section c2 is interpolated too (the nc==2 Hermite v-solve pins the
+    // surface to every section, not just the ends). Project each sampled point of
+    // c2 onto the surface and check it lies on it.
+    for (auto u_ : gbs::make_range(k.front(), k.back(), 20))
+    {
+        auto [u_s, v_s, d] = gbs::extrema_surf_pnt(s, c2(u_), 1e-7);
+        ASSERT_LT( d, 1e-6 );
+    }
+
+    if(PLOT_ON)
+        gbs::plot(s,c1,c2,c3,sp);
+}
 
 TEST(tests_bssbuild, gordon_bss)
 {


### PR DESCRIPTION
## Summary

Lofting **rational** curves **with a spine** (`gbs::loft(std::list<BSCurveGeneral<T,dim,true>*>, spine)`) previously did **not compile**, and the spine-tangent assembly mixed homogeneous pole coordinates with model-space spine tangents.

Root cause (`get_tg_from_spine`):
- `spine.value(v,1)` is a model-space tangent (`array<T,dim>`), but it was stored into `std::vector<array<T,dim+rational>>` → *"no viable overloaded '='"*.
- The weighted-tangent lambda took `norm(pts[k+1]-pts[k])` on **homogeneous** poles, folding the weights into the chord-length scaling.

## Fix (only `gbs/bssbuild.h`)

Derive the homogeneous v-tangent from first principles. Moving a pole along the spine direction is a **constant-weight** model-space displacement: with the homogeneous pole `P^w = (w·P, w)`,

```
P^w(t) = ( w·(P + t·V), w )   =>   dP^w/dt = ( w·V, 0 )
```

So the spatial part is scaled by the pole weight `w` and the weight component is **null by derivation** (not zeroed to silence the compiler). This is factored into a new `spine_tangent_to_pole` helper.

The spine tangent is kept in model space (`array<T,dim>`), and the column poles are projected to model space (`weight_projected_pole`) before chord-length scaling, so the scaling stays consistent with the model-space spine distances. The non-rational path is preserved **bit-for-bit** (`pm == pts`, helper returns `s·V`).

## Tests

Re-enabled `tests_bssbuild.loft_rational_with_spine` (it was left commented in #57 because it was a *compile* failure, not a logic one). It asserts:
- the surface type is `BSSurfaceRational<double,3>` (`static_assert`),
- exact boundary pass-through at `v_min`/`v_max` (homogeneous net reproduces c1/c3 to machine precision),
- interior interpolation of the middle section c2 via `extrema_surf_pnt`.

`tests_bssbuild`: **16/16 cases, 2816 assertions, green** — no regression in `loft_with_spine` (non-rational) or `loft_rational` (no spine).

Closes #58. Refs #57, #40, epic #44.