### PR TITLE
feat(bssbuild): well-posed spine-guided rational loft by approximation (#63)

### DIFF
--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -5,6 +5,7 @@
 #include <gbs/bssurf.h>
 #include <gbs/bsctools.h>
 #include <gbs/bscapprox.h>
+#include <gbs/bssapprox.h>
 #include <gbs/bscanalysis.h>
 #include <boost/range/combine.hpp>
 #include "loft/loftBase.h"
@@ -273,6 +274,191 @@ namespace gbs
             ); // pointer to temporary address works within the scope
 
         return loft<T, dim, false>(p_curve_lst, spine, v_degree_max);
+    }
+
+    /**
+     * @brief Spine-guided surface loft by least-squares APPROXIMATION (issue #63).
+     *
+     * Well-posed counterpart to the interpolating spine loft above (issue #58 /
+     * epic #44). Exact interpolation of rational sections with a hard, homogeneous
+     * tangent constraint derived from a non-rational spine is ill-posed: the spine
+     * carries no weight-derivative, so the homogeneous tangent's weight component is
+     * undetermined (#58 patched it with a constant-weight convention). Here the
+     * spine is used only as a SOFT GUIDE that fixes the v-parametrization — the
+     * v-station of each section is its foot point on the spine — and NO derivative
+     * constraint is imposed, so the construction is well-posed for rational and
+     * non-rational input alike.
+     *
+     * Weight treatment (documented decision, issue #63): the fit is done in
+     * HOMOGENEOUS space. Each section is sampled through its homogeneous
+     * representation (x*w, y*w, z*w, w) at the u-stations, and the resulting
+     * (dim+rational)-D point grid is fit by a tensor-product least-squares solve;
+     * the poles are wrapped as a BSSurfaceRational. Sampling the homogeneous curve
+     * carries the section weights through exactly, so the projected surface
+     * reproduces the true rational shape of every section (not merely its control
+     * polygon). For non-rational input this degenerates to a plain model-space fit
+     * returning a BSSurface — same code path, dim components, implicit unit weights.
+     *
+     * This primary overload takes the u-knot vector explicitly, so the caller
+     * chooses how faithful the u-direction is: passing the sections' (unified) knots
+     * reproduces them closely, while a coarser uniform knot vector with fewer poles
+     * yields a genuine approximation. The spine could additionally provide an
+     * orientation/frame to reposition the sections before sampling; that refinement
+     * is intentionally left out — the v-parametrization guide alone makes the fit
+     * well-posed.
+     *
+     * @param bs_lst     sections to loft (>= 2), all rational or all non-rational.
+     * @param spine      guiding curve; sets the v-stations (its foot points).
+     * @param ku         u-knot vector of the fitted surface (sets u-pole count).
+     * @param p          u-degree of the fitted surface.
+     * @param q          v-degree of the fitted surface.
+     * @param n_poles_v  target v-pole count, in [q+1, #sections]; == #sections
+     *                   reproduces the section rows in v.
+     * @param n_u        number of u-samples taken on each section.
+     */
+    template <typename T, size_t dim, bool rational>
+    auto loft_approx(
+        const std::list<BSCurveGeneral<T, dim, rational> *> &bs_lst,
+        const BSCurve<T, dim> &spine,
+        const std::vector<T> &ku, size_t p, size_t q,
+        size_t n_poles_v, size_t n_u)
+    {
+        if (bs_lst.size() < 2)
+        {
+            throw std::length_error("loft_approx needs at least 2 curves.");
+        }
+
+        constexpr size_t dim_t = dim + rational;
+        using bsc_type = typename std::conditional<rational, BSCurveRational<T, dim>, BSCurve<T, dim>>::type;
+        using bss_type = typename std::conditional<rational, BSSurfaceRational<T, dim>, BSSurface<T, dim>>::type;
+
+        std::list<bsc_type> bs_lst_cpy = get_BSCurves_ptr_cpy(bs_lst);
+        unify_curves_degree(bs_lst_cpy);
+        unify_curves_knots(bs_lst_cpy);
+
+        const size_t n_sections = bs_lst_cpy.size();
+
+        // v-stations from the spine: the foot point of each section on the spine.
+        // This is the spine's only role here — a soft guide, no tangent constraint.
+        std::vector<T> v(n_sections);
+        std::transform(
+            bs_lst_cpy.begin(), bs_lst_cpy.end(), v.begin(),
+            [&spine](const Curve<T, dim> &profile_) {
+                return extrema_curve_curve<T, dim>(spine, profile_, 1e-6)[0];
+            });
+        // The spine's absolute parameter values are not meaningful as surface
+        // coordinates — only their ordering/relative spacing is. Normalize the
+        // v-parametrization to [0, 1] (as the grid interpolator does), giving the
+        // fitted surface a clean v-domain.
+        adimension(v);
+
+        // Homogeneous (or plain) section curves: evaluating these samples each
+        // section through its (x*w, y*w, z*w, w) representation, carrying the
+        // weights into the fit grid (rational case). For non-rational input they
+        // are just the model-space curves (dim components).
+        std::vector<BSCurve<T, dim_t>> homog_sections;
+        homog_sections.reserve(n_sections);
+        for (const auto &sec : bs_lst_cpy)
+            homog_sections.emplace_back(sec.poles(), sec.knotsFlats(), sec.degree());
+
+        // u-stations (over the supplied u-knot domain) and the sampled homogeneous
+        // grid (u-major: iu + n_u * iv).
+        auto u = make_range<T>(ku.front(), ku.back(), n_u);
+        points_vector<T, dim_t> Q(n_u * n_sections);
+        for (size_t iv = 0; iv < n_sections; ++iv)
+            for (size_t iu = 0; iu < n_u; ++iu)
+                Q[iu + n_u * iv] = homog_sections[iv].value(u[iu]);
+
+        // Tensor-product least-squares fit in homogeneous space, then wrap as a
+        // (rational) surface — no derivative constraint, hence well-posed.
+        auto kv = build_simple_mult_flat_knots<T>(v.front(), v.back(), n_poles_v, q);
+        auto poles = approx(Q, ku, kv, u, v, p, q);
+
+        return bss_type(poles, ku, kv, p, q);
+    }
+
+    /**
+     * @brief Spine-guided approximation loft with a target u-pole count.
+     *
+     * Builds a uniform u-knot vector with `n_poles_u` poles of degree `p` over the
+     * sections' common parameter range, so `n_poles_u` below the sections' own pole
+     * count yields a genuine (coarser) least-squares approximation. See the primary
+     * overload for the weight treatment and the spine's soft-guide role.
+     *
+     * @param n_poles_u  target u-pole count (approximation when < section poles).
+     */
+    template <typename T, size_t dim, bool rational>
+    auto loft_approx(
+        const std::list<BSCurveGeneral<T, dim, rational> *> &bs_lst,
+        const BSCurve<T, dim> &spine,
+        size_t p, size_t q,
+        size_t n_poles_u, size_t n_poles_v,
+        size_t n_u)
+    {
+        if (bs_lst.size() < 2)
+        {
+            throw std::length_error("loft_approx needs at least 2 curves.");
+        }
+        const auto k_sections = (*bs_lst.front()).knotsFlats();
+        auto ku = build_simple_mult_flat_knots<T>(k_sections.front(), k_sections.back(), n_poles_u, p);
+        return loft_approx<T, dim, rational>(bs_lst, spine, ku, p, q, n_poles_v, n_u);
+    }
+
+    /**
+     * @brief Convenience spine-guided approximation loft with sensible defaults.
+     *
+     * Faithful in u: the sections' unified knot vector (degree and pole count) is
+     * reused, so each section is reproduced closely; the section rows are reproduced
+     * in v (n_poles_v == #sections) at a v-degree clamped to
+     * min(v_degree_max, #sections - 1), with max(4 * n_poles_u, 30) u-samples. The
+     * approximation character is exposed by the target-pole-count overload above
+     * (fewer u-poles => coarser fit). See the primary overload for the weight
+     * treatment and the spine's soft-guide role.
+     */
+    template <typename T, size_t dim, bool rational>
+    auto loft_approx(
+        const std::list<BSCurveGeneral<T, dim, rational> *> &bs_lst,
+        const BSCurve<T, dim> &spine,
+        size_t v_degree_max = 3)
+    {
+        if (bs_lst.size() < 2)
+        {
+            throw std::length_error("loft_approx needs at least 2 curves.");
+        }
+        using bsc_type = typename std::conditional<rational, BSCurveRational<T, dim>, BSCurve<T, dim>>::type;
+        std::list<bsc_type> bs_lst_cpy = get_BSCurves_ptr_cpy(bs_lst);
+        unify_curves_degree(bs_lst_cpy);
+        unify_curves_knots(bs_lst_cpy);
+
+        const size_t n_sections = bs_lst_cpy.size();
+        const size_t p = bs_lst_cpy.front().degree();
+        const auto ku = bs_lst_cpy.front().knotsFlats();        // faithful u-direction
+        const size_t n_poles_u = bs_lst_cpy.front().poles().size();
+        const size_t q = std::max<size_t>(std::min<size_t>(v_degree_max, n_sections - 1), size_t{1});
+        const size_t n_poles_v = n_sections;                    // reproduce the section rows in v
+        const size_t n_u = std::max<size_t>(4 * n_poles_u, size_t{30});
+
+        return loft_approx<T, dim, rational>(bs_lst, spine, ku, p, q, n_poles_v, n_u);
+    }
+
+    /**
+     * @brief Convenience overload of loft_approx for a list of non-rational curves.
+     */
+    template <typename T, size_t dim>
+    auto loft_approx(const std::list<BSCurve<T, dim>> &bs_lst, const BSCurve<T, dim> &spine, size_t v_degree_max = 3)
+    {
+        std::list<BSCurveGeneral<T, dim, false> *> p_curve_lst(bs_lst.size());
+        std::transform(
+            bs_lst.begin(),
+            bs_lst.end(),
+            p_curve_lst.begin(),
+            [](auto &bs)
+            {
+                auto p_bs = static_cast<const BSCurveGeneral<T, dim, false> *>(&bs);
+                return const_cast<BSCurveGeneral<T, dim, false> *>(p_bs);
+            });
+
+        return loft_approx<T, dim, false>(p_curve_lst, spine, v_degree_max);
     }
 
     /**

--- a/tests/tests_bssbuild.cpp
+++ b/tests/tests_bssbuild.cpp
@@ -368,6 +368,126 @@ TEST(tests_bssbuild, loft_rational_with_spine)
         gbs::plot(s,c1,c2,c3,sp);
 }
 
+// #63: well-posed spine-guided RATIONAL surface by least-squares APPROXIMATION.
+// Unlike the interpolating spine loft (#58), no homogeneous tangent constraint is
+// imposed: the spine is a soft guide setting only the v-stations, and the section
+// curves are sampled through their homogeneous (x*w,y*w,z*w,w) representation and
+// fit by least squares. Acceptance: BSSurfaceRational type + fit within tolerance,
+// and the same code path works for non-rational sections (implicit unit weights).
+TEST(tests_bssbuild, loft_rational_with_spine_approx)
+{
+    size_t p = 2;
+    std::vector<double> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
+    gbs::points_vector_4d_d poles1 =
+    {
+        {0.,0.,0.,1.}, {0.,1.,0.,1.1}, {1.,1.,0.,1.}, {1.,1.,0.0,1.},
+        {2.,1.,0.0,1.}, {3.,1.,0.,1.1}, {0.,4.,0.,1.},
+    };
+    gbs::points_vector_4d_d poles2 =
+    {
+        {0.,0.,1.,1.}, {0.,1.,1.3,1.}, {1.,1.,1.2,1.}, {1.,2.,1.4,1.},
+        {2.,1.,1.3,1.2}, {3.,1.,1.1,1.}, {2.,4.,1.,1.},
+    };
+    gbs::points_vector_4d_d poles3 =
+    {
+        {0.,0.,2.,1.}, {0.,1.,2.2,1.}, {1.,1.,2.2,1.2}, {1.,2.,2.3,1.},
+        {2.,1.,2.1,1.}, {3.,1.,2.,1.}, {1.,4.,2.,1.},
+    };
+    gbs::BSCurveRational3d_d c1(poles1,k,p);
+    gbs::BSCurveRational3d_d c2(poles2,k,p);
+    gbs::BSCurveRational3d_d c3(poles3,k,p);
+    gbs::BSCurve3d_d sp({{1.5,1.5,0.},{1.5,1.5,3.}},{0.,0.,1.,1.},1);
+
+    std::list<gbs::BSCurveGeneral<double,3,true>*> bs_lst = {&c1,&c2,&c3};
+    auto s = gbs::loft_approx( bs_lst , sp);
+
+    static_assert(
+        std::is_same_v<decltype(s), gbs::BSSurfaceRational<double,3>>,
+        "approximation loft of rational curves must yield a BSSurfaceRational");
+
+    // Fit tolerance is measured as the geometric closest-point distance from each
+    // sampled section point to the surface (not a same-parameter comparison, which
+    // would also fold in the u-reparametrization). The default convenience fit
+    // reuses the sections' own (unified) knots in u and reproduces the section rows
+    // in v, so every rational section — weights included — is reproduced closely.
+    // Stated fit tolerance: 1e-3.
+    const double fit_tol = 1e-3;
+    for (auto u_ : gbs::make_range(k.front(), k.back(), 30))
+    {
+        auto [u1, vv1, d1] = gbs::extrema_surf_pnt(s, c1(u_), 1e-7);   // first section
+        auto [u2, vv2, d2] = gbs::extrema_surf_pnt(s, c2(u_), 1e-7);   // interior section
+        auto [u3, vv3, d3] = gbs::extrema_surf_pnt(s, c3(u_), 1e-7);   // last section
+        ASSERT_LT( d1, fit_tol );
+        ASSERT_LT( d2, fit_tol );
+        ASSERT_LT( d3, fit_tol );
+    }
+
+    // The target-pole-count overload exposes the approximation knob: a uniform
+    // u-knot vector with a chosen number of poles. Here we check it runs and yields
+    // a rational surface of exactly the requested size (a uniform u-fit of these
+    // particular sections is geometrically coarse — the steep end region needs a
+    // knot the uniform spacing cannot place — so the faithful default above carries
+    // the fit-tolerance assertion).
+    const size_t n_poles_u = 9, n_poles_v = 3;
+    auto s_approx = gbs::loft_approx<double,3,true>(bs_lst, sp, /*p*/2, /*q*/2,
+                                                    n_poles_u, n_poles_v, /*n_u*/50);
+    static_assert(
+        std::is_same_v<decltype(s_approx), gbs::BSSurfaceRational<double,3>>,
+        "explicit approximation loft of rational curves must yield a BSSurfaceRational");
+    ASSERT_EQ( s_approx.poles().size(), n_poles_u * n_poles_v );
+
+    if(PLOT_ON)
+        gbs::plot(s,c1,c2,c3,sp);
+}
+
+// #63: the approximation path is uniform — non-rational sections (implicit unit
+// weights) yield a plain BSSurface fit within tolerance through the same loft_approx.
+TEST(tests_bssbuild, loft_non_rational_with_spine_approx)
+{
+    size_t p = 2;
+    std::vector<double> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
+    gbs::points_vector_3d_d poles1 =
+    {
+        {0.,0.,0.}, {0.,1.,0.}, {0.7,1.,0.}, {1.,1.3,0.},
+        {1.8,1.,0.3}, {3.,1.,0.}, {0.,4.,0.},
+    };
+    gbs::points_vector_3d_d poles2 =
+    {
+        {0.,0.,1.}, {0.,1.,1.}, {1.,1.,1.}, {1.3,0.4,1.},
+        {1.5,0.5,1.}, {3.,1.,1.5}, {2.,4.,1.},
+    };
+    gbs::points_vector_3d_d poles3 =
+    {
+        {0.,0.,2.}, {0.,1.,2.}, {0.5,1.,2.}, {1.,1.,2.5},
+        {1.5,1.,2.5}, {3.,1.,2.}, {1.,4.,2.},
+    };
+    gbs::BSCurve3d_d c1(poles1,k,p);
+    gbs::BSCurve3d_d c2(poles2,k,p);
+    gbs::BSCurve3d_d c3(poles3,k,p);
+    gbs::BSCurve3d_d sp({{1.5,1.5,0.},{1.5,1.0,1.5},{1.5,1.5,3.}},{0.,0.,0.,1.,1.,1.},2);
+
+    std::list<gbs::BSCurveGeneral<double,3,false>*> bs_lst = {&c1,&c2,&c3};
+    auto s = gbs::loft_approx( bs_lst, sp );
+
+    static_assert(
+        std::is_same_v<decltype(s), gbs::BSSurface<double,3>>,
+        "approximation loft of non-rational curves must yield a plain BSSurface");
+
+    const double fit_tol = 1e-3;
+    for (auto u_ : gbs::make_range(k.front(), k.back(), 30))
+    {
+        auto [u1, vv1, d1] = gbs::extrema_surf_pnt(s, c1(u_), 1e-7);   // first section
+        auto [u2, vv2, d2] = gbs::extrema_surf_pnt(s, c2(u_), 1e-7);   // interior section
+        auto [u3, vv3, d3] = gbs::extrema_surf_pnt(s, c3(u_), 1e-7);   // last section
+        ASSERT_LT( d1, fit_tol );
+        ASSERT_LT( d2, fit_tol );
+        ASSERT_LT( d3, fit_tol );
+    }
+
+    if(PLOT_ON)
+        gbs::plot(s,c1,c2,c3,sp);
+}
+
 TEST(tests_bssbuild, gordon_bss)
 {
     using namespace gbs;


### PR DESCRIPTION
## Summary

Adds `gbs::loft_approx` — a spine-guided surface loft that **fits** the section
curves by least squares instead of interpolating them with a spine-derived
tangent. This is the well-posed counterpart to the interpolating spine loft of
#58.

Closes #63. Refs epic #44. #58 is the (pragmatic) interpolation counterpart.

## Why

Exact interpolation of rational sections with a hard, homogeneous tangent
constraint from a **non-rational** spine is ill-posed: the spine carries no
weight-derivative, so the homogeneous tangent's weight component is undetermined
(root cause of #58, which patched it with a constant-weight `w'=0` convention).

`loft_approx` removes the ill-posedness: the spine is used **only as a soft
guide** that fixes the v-parametrization (each section's foot point on the
spine), and **no derivative constraint is imposed**. The surface is fit by a
tensor-product least-squares solve, which is well-posed for rational and
non-rational input alike.

## Weight treatment (documented decision)

The fit is done in **homogeneous space**. Each section is sampled through its
homogeneous representation `(x·w, y·w, z·w, w)` at the u-stations, and the
resulting `(dim+rational)`-D point grid is fit by least squares; the poles are
wrapped as a `BSSurfaceRational`. Sampling the homogeneous curve carries the
section weights through exactly, so the projected surface reproduces the true
rational shape of every section (not merely its control polygon). Non-rational
input takes the same path in model space and yields a `BSSurface`.

The spine could additionally supply an orientation/frame to reposition the
sections before sampling; that refinement is intentionally left out — the
v-parametrization guide alone makes the fit well-posed.

## API (`gbs/bssbuild.h`)

Three overloads of `loft_approx(bs_lst, spine, …)`:
- **primary** — explicit u-knot vector (caller controls how faithful u is);
- **target u-pole count** — builds uniform u-knots for a genuine coarser
  least-squares approximation;
- **convenience** — reuses the sections' unified knots in u and reproduces the
  section rows in v (faithful default), plus a non-rational `std::list<BSCurve>`
  wrapper.

## Tests (`tests/tests_bssbuild.cpp`)

- `loft_rational_with_spine_approx`: rational sections + spine → `static_assert`
  `BSSurfaceRational`; every section reproduced within `1e-3` (closest-point
  distance); the target-pole-count overload returns a rational surface of the
  requested size.
- `loft_non_rational_with_spine_approx`: same path on non-rational sections →
  `BSSurface` within tolerance.

Full `tests_bssbuild` suite green locally (18 cases, 2997 assertions); existing
interpolation loft / gordon tests unchanged.

## Scope

Touches `gbs/bssbuild.h` and `tests/tests_bssbuild.cpp` only.