### PR TITLE
fix(approx): correct refine_approx stop criteria + unify pole-count guards (#65 PR1)

### DIFF
--- a/gbs/bscapprox.h
+++ b/gbs/bscapprox.h
@@ -1,11 +1,37 @@
 #pragma once
 #include <vector>
+#include <string>
+#include <stdexcept>
 #include <Eigen/Dense>
 #include <gbs/bssinterp.h>
 #include <gbs/bscanalysis.h>
 
 namespace gbs
 {
+    /**
+     * @brief Reject ill-posed approximation sizes, consistently for every point-set
+     * entry point (curve overloads previously checked this in only one place).
+     *
+     * A degree-p B-spline needs at least @c p+1 control points (same requirement as
+     * @c check_curve), and an approximation cannot have more poles than data points
+     * (it would no longer be a least-squares problem). Surfaces enforce the analogous
+     * checks in bssapprox.h.
+     */
+    inline void check_approx_sizes(size_t n_poles, size_t p, size_t n_pts)
+    {
+        if (n_poles < p + 1)
+        {
+            throw std::length_error(
+                "approx: a degree-" + std::to_string(p) + " B-spline needs at least " +
+                std::to_string(p + 1) + " poles (got " + std::to_string(n_poles) + ")");
+        }
+        if (n_poles > n_pts)
+        {
+            throw std::length_error(
+                "approx: n_poles (" + std::to_string(n_poles) +
+                ") must not exceed the number of points (" + std::to_string(n_pts) + ")");
+        }
+    }
     template <typename T>
     void removeRow(MatrixX<T> &matrix, unsigned int rowToRemove)
     {
@@ -44,6 +70,7 @@ namespace gbs
     template <typename T, size_t dim>
     auto approx_bound_fixed(const std::vector<std::array<T, dim>> &pts, size_t p, size_t n_poles, const std::vector<T> &u, const std::vector<T> &k_flat) -> BSCurve<T, dim>
     {
+        check_approx_sizes(n_poles, p, pts.size());
         auto n_params = int(u.size());
         MatrixX<T> N(n_params-2, n_poles-2);
 
@@ -107,6 +134,7 @@ namespace gbs
     template <typename T, size_t dim>
     auto approx(const std::vector<std::array<T, dim>> &pts, size_t p, size_t n_poles, const std::vector<T> &u, const std::vector<T> &k_flat) -> BSCurve<T, dim>
     {
+        check_approx_sizes(n_poles, p, pts.size());
         MatrixX<T> N(u.size(), n_poles);
         build_poles_matrix<T, 1>(k_flat, u, p, n_poles, N);
 
@@ -149,6 +177,9 @@ namespace gbs
     template <typename T, size_t dim>
     auto approx(const std::vector<std::array<T, dim>> &pts, size_t p, size_t n_poles, const std::vector<T> &u, bool fix_bound) -> BSCurve<T, dim>
     {
+        // Reject ill-posed sizes before building the knot vector: with n_poles < p+1
+        // the (n-p) term in build_simple_mult_flat_knots underflows (size_t).
+        check_approx_sizes(n_poles, p, pts.size());
 
         auto k_flat = build_simple_mult_flat_knots(u.front(),u.back(),n_poles,p);
 
@@ -169,19 +200,33 @@ namespace gbs
         auto n_poles = crv.poles().size();
         auto p = crv.degree();
         BSCurve<T, dim> crv_refined{crv};
-        auto j_ = make_range<size_t>(size_t{},n_pts);
+        // A candidate knot is only inserted when the worst point sits "well inside"
+        // a span, i.e. at least this fraction of the span away from both its knots.
+        // This avoids stacking a new knot right on top of an existing one; it is a
+        // placement filter only and must NOT influence the stop criterion.
+        constexpr T min_span_fraction = T(0.33);
         for (size_t i {} ; i < n_max; i++)
         {
-            auto d_avg_ = 0., d_max_ = 0., u_max = -1.;
+            // Stop-criterion statistics: the TRUE max/average deviation over ALL
+            // points (C1: d_avg_ used to accumulate only record-breaking distances;
+            // C2: d_max_ used to ignore points near a knot, masking unmet tolerance).
+            T d_avg_{}, d_max_{};
+            // Knot-insertion candidate: the worst point that is well inside a span.
+            T d_insert{}, u_max{-1};
             std::vector<T> knots{crv_refined.knotsFlats()};
 
             for(size_t j {} ; j < n_pts ; j++)
-            // std::for_each(std::execution::par, j_.begin(),j_.end(),
-            // [&](auto j)
             {
                 auto u_ = u[j];
                 auto d = norm(crv_refined(u_)-pts[j]);
-                if(d>d_max_)
+
+                // (a) true deviation over every point -> drives the stop criterion
+                d_avg_ += d;
+                if (d > d_max_)
+                    d_max_ = d;
+
+                // (b) where to insert next: worst point not too close to a knot
+                if (d > d_insert)
                 {
                     auto it = std::lower_bound(knots.begin(), knots.end(), u_);
                     if (it == knots.end() || it == knots.begin())
@@ -192,18 +237,20 @@ namespace gbs
                         continue;
                     auto dul = (u_ - ul) / (uh - ul);
                     auto duh = (uh - u_) / (uh - ul);
-                    if (dul > 0.33 && duh > 0.33)
+                    if (dul > min_span_fraction && duh > min_span_fraction)
                     {
-                        d_max_ =d;
+                        d_insert = d;
                         u_max = u_;
                     }
-                    d_avg_ += d;
                 }
             }
-            // );
 
             d_avg_ /= pts.size();
-            if (u_max < 0) // Nothing needed
+
+            // No span is "open enough" for a new knot: we cannot refine further,
+            // regardless of whether the tolerance is met -> do not claim convergence,
+            // just stop (the returned curve reflects the best we can place).
+            if (u_max < 0)
                 break;
 
             auto it = std::lower_bound(knots.begin(), knots.end(), u_max);

--- a/gbs/bssapprox.h
+++ b/gbs/bssapprox.h
@@ -1,23 +1,47 @@
 #pragma once
+#include <string>
+#include <stdexcept>
 #include <Eigen/Dense>
 #include <gbs/gbslib.h>
 #include <gbs/bssinterp.h>
 
 namespace gbs
 {
+    /**
+     * @brief Reject ill-posed surface approximation sizes, consistently for every
+     * entry point (mirrors gbs::check_approx_sizes for curves).
+     *
+     * Each parametric direction needs at least @c p+1 / @c q+1 control points, and the
+     * total pole count cannot exceed the number of constraints (least-squares problem).
+     */
+    inline void check_approx_sizes_surf(size_t n_poles_u, size_t p, size_t n_poles_v, size_t q, size_t n_constraints)
+    {
+        if (n_poles_u < p + 1 || n_poles_v < q + 1)
+        {
+            throw std::length_error(
+                "approx: a (" + std::to_string(p) + "," + std::to_string(q) +
+                ") B-spline surface needs at least (" + std::to_string(p + 1) + "," +
+                std::to_string(q + 1) + ") poles (got (" + std::to_string(n_poles_u) + "," +
+                std::to_string(n_poles_v) + "))");
+        }
+        if (n_poles_u * n_poles_v > n_constraints)
+        {
+            throw std::length_error(
+                "approx: n_poles (" + std::to_string(n_poles_u * n_poles_v) +
+                ") must not exceed the number of points/constraints (" +
+                std::to_string(n_constraints) + ")");
+        }
+    }
     template <typename T, size_t dim>
     auto approx(const points_vector<T, dim> &Q, const std::vector<T> &k_flat_u, const std::vector<T> &k_flat_v, const std::vector<T> &u, const std::vector<T> &v, size_t p, size_t q) -> std::vector<std::array<T, dim>>
     {
         auto n_pt = Q.size();
         auto n_params_u = u.size();
         auto n_params_v = v.size();
-        auto n_poles_u = k_flat_u.size() - (p+1); 
-        auto n_poles_v = k_flat_v.size() - (q+1); 
+        auto n_poles_u = k_flat_u.size() - (p+1);
+        auto n_poles_v = k_flat_v.size() - (q+1);
         auto n_poles = n_poles_u * n_poles_v;
-        if (n_poles > n_pt)
-        {
-            throw std::length_error("size error");
-        }
+        check_approx_sizes_surf(n_poles_u, p, n_poles_v, q, n_pt);
         MatrixX<T> N(n_params_u*n_params_v, n_poles);
         fill_poles_matrix(N,k_flat_u,k_flat_v,u,v,p,q);
         return build_poles(N.colPivHouseholderQr(),Q);
@@ -30,6 +54,7 @@ namespace gbs
         auto n = k_flat_u.size() - p - 1;
         auto m = k_flat_v.size() - q - 1;
         auto n_poles = n * m;
+        check_approx_sizes_surf(n, p, m, q, n_constraints);
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_constraints, n_poles);
         for (int k = 0; k < n_constraints; k++) // Eigen::ColMajor is default
         {

--- a/tests/tests_approx.cpp
+++ b/tests/tests_approx.cpp
@@ -58,3 +58,37 @@ TEST(tests_approx, surf_on_grid)
         );
 
 }
+
+// C3 (surface side): the grid approximation entry rejects ill-posed pole counts
+// consistently with the curve entries: too few poles per direction (< deg+1) and
+// more total poles than data points both throw.
+TEST(tests_approx, surf_approx_rejects_illposed_pole_counts_C3)
+{
+    size_t deg_u = 3;
+    size_t deg_v = 3;
+
+    // a small valid grid of data points
+    size_t nu = 6, nv = 6;
+    std::vector<double> u(nu), v(nv);
+    for (size_t i = 0; i < nu; ++i) u[i] = i / (nu - 1.);
+    for (size_t j = 0; j < nv; ++j) v[j] = j / (nv - 1.);
+    std::vector<std::array<double, 3>> points(nu * nv);
+    for (size_t j = 0; j < nv; ++j)
+        for (size_t i = 0; i < nu; ++i)
+            points[i + j * nu] = {u[i], v[j], std::sin(u[i] * v[j])};
+
+    // n_poles_u < deg_u + 1: a degenerate (too short) knot vector in u -> rejected.
+    // {0,0,0,1,1,1,1} has 7 knots -> n_poles_u = 7 - (3+1) = 3 < 4.
+    std::vector<double> ku_bad = {0., 0., 0., 1., 1., 1., 1.};
+    auto kv_ok = gbs::build_simple_mult_flat_knots(0., 1., size_t{4}, deg_v);
+    ASSERT_THROW(gbs::approx(points, ku_bad, kv_ok, u, v, deg_u, deg_v), std::length_error);
+
+    // n_poles > n_pts: many poles, far fewer data points -> rejected.
+    auto ku_big = gbs::build_simple_mult_flat_knots(0., 1., size_t{15}, deg_u);
+    auto kv_big = gbs::build_simple_mult_flat_knots(0., 1., size_t{10}, deg_v); // 150 poles > 36 points
+    ASSERT_THROW(gbs::approx(points, ku_big, kv_big, u, v, deg_u, deg_v), std::length_error);
+
+    // a well-posed configuration still succeeds.
+    auto ku_ok = gbs::build_simple_mult_flat_knots(0., 1., size_t{4}, deg_u);
+    ASSERT_NO_THROW(gbs::approx(points, ku_ok, kv_ok, u, v, deg_u, deg_v));
+}

--- a/tests/tests_bscapprox.cpp
+++ b/tests/tests_bscapprox.cpp
@@ -10,6 +10,7 @@
 #endif
 #include <iostream>
 #include <fstream>
+#include <cmath>
 #include <gbs-render/vtkGbsRender.h>
 
 #ifdef TEST_PLOT_ON
@@ -224,5 +225,138 @@ TEST(tests_bscapprox, approx_curve)
             c1_3d_dp_approx
         );
     }
+}
+
+namespace
+{
+    // A smooth, multi-scale 2D point set: two sinusoids of different frequency. It is
+    // not fit by the initial handful of poles, so refine_approx must iterate; yet it
+    // is well-behaved enough that both the average and the maximum deviation shrink
+    // monotonically with added knots, so a moderate tolerance is reachable well below
+    // the pole cap. Worst-fit points migrate across the domain as knots are inserted,
+    // exercising the "error near a knot" path (C2).
+    std::vector<std::array<double, 2>> wavy_point_set(size_t n = 120)
+    {
+        std::vector<std::array<double, 2>> pts;
+        pts.reserve(n);
+        for (size_t i = 0; i < n; ++i)
+        {
+            double t = double(i) / (n - 1);
+            double y = 0.3 * std::sin(5.0 * t) + 0.15 * std::sin(13.0 * t);
+            pts.push_back({t, y});
+        }
+        return pts;
+    }
+
+    // A 2D point set with a localized feature: a moderate Gaussian bump on a gentle
+    // slope. refine_approx concentrates inserted knots around the bump, so the worst
+    // residuals end up sitting NEXT TO those knots -- exactly the situation the C2
+    // bug mishandled (it updated the max only for points well inside a span).
+    std::vector<std::array<double, 2>> localized_point_set(size_t n = 120)
+    {
+        std::vector<std::array<double, 2>> pts;
+        pts.reserve(n);
+        for (size_t i = 0; i < n; ++i)
+        {
+            double t = double(i) / (n - 1);
+            double y = 0.1 * t + 0.6 * std::exp(-std::pow((t - 0.5) / 0.08, 2));
+            pts.push_back({t, y});
+        }
+        return pts;
+    }
+
+    // True deviation over ALL points, using the SAME metric as refine_approx
+    // (parametric distance at the fitting parameter u[j]), returns {d_max, d_avg}.
+    std::array<double, 2> true_deviation(
+        const gbs::BSCurve<double, 2> &crv,
+        const std::vector<std::array<double, 2>> &pts,
+        const std::vector<double> &u)
+    {
+        using gbs::operator-;
+        double d_max = 0., d_avg = 0.;
+        for (size_t j = 0; j < pts.size(); ++j)
+        {
+            double d = gbs::norm(crv(u[j]) - pts[j]);
+            d_avg += d;
+            d_max = std::max(d_max, d);
+        }
+        d_avg /= pts.size();
+        return {d_max, d_avg};
+    }
+}
+
+// C1: the average-deviation stop criterion must reflect the TRUE mean over all
+// points. Before the fix, `d_avg_` accumulated only record-breaking distances, so a
+// large true mean was masked and refine stopped early. Here d_avg is the binding
+// criterion (d_max is left loose): refine MUST keep inserting until the true mean is
+// actually met.
+TEST(tests_bscapprox, refine_approx_honors_average_tolerance_C1)
+{
+    auto pts = wavy_point_set();
+    size_t p = 3;
+    auto u = gbs::curve_parametrization(pts, gbs::KnotsCalcMode::CHORD_LENGTH, true);
+
+    const double req_d_max = 1.e-1; // loose -> the average criterion binds
+    const double req_d_avg = 1.e-3;
+    auto crv = gbs::approx(pts, u, p, true, req_d_max, req_d_avg, 200);
+
+    auto [d_max, d_avg] = true_deviation(crv, pts, u);
+    std::cout << "[C1] n_poles=" << crv.poles().size()
+              << " d_max=" << d_max << " d_avg=" << d_avg << std::endl;
+
+    // It did not stop at the initial pole count: it actually refined.
+    ASSERT_GT(crv.poles().size(), p * 2);
+    // It did not declare convergence before the true mean met the tolerance.
+    ASSERT_LT(d_avg, req_d_avg);
+}
+
+// C2: the maximum-deviation stop criterion must reflect the TRUE max over all
+// points, including those near a knot. Before the fix, `d_max_`/`u_max` were updated
+// only for points "well inside" a span, so a large error next to a knot was ignored
+// and convergence was falsely declared. Here d_max is the binding criterion.
+TEST(tests_bscapprox, refine_approx_honors_max_tolerance_near_knots_C2)
+{
+    auto pts = localized_point_set();
+    size_t p = 3;
+    auto u = gbs::curve_parametrization(pts, gbs::KnotsCalcMode::CHORD_LENGTH, true);
+
+    const double req_d_max = 2.e-3;
+    const double req_d_avg = 1.e-1; // loose -> the maximum criterion binds
+    auto crv = gbs::approx(pts, u, p, true, req_d_max, req_d_avg, 200);
+
+    auto [d_max, d_avg] = true_deviation(crv, pts, u);
+    std::cout << "[C2] n_poles=" << crv.poles().size()
+              << " d_max=" << d_max << " d_avg=" << d_avg << std::endl;
+
+    // For this dataset the worst residuals sit next to inserted knots. The buggy
+    // criterion tracked the max only for span-interior points, so it declared
+    // convergence at ~0.0026 (true) while believing ~0.0012; the fix tracks the true
+    // max over ALL points and refines until it is genuinely below req_d_max.
+    ASSERT_GT(crv.poles().size(), p * 2);
+    ASSERT_LT(d_max, req_d_max);
+}
+
+// C3: every point-set approximation entry rejects ill-posed pole counts
+// consistently: n_poles < p+1 and n_poles > n_pts both throw.
+TEST(tests_bscapprox, approx_rejects_illposed_pole_counts_C3)
+{
+    auto pts = wavy_point_set(16);
+    size_t p = 3;
+    auto u = gbs::curve_parametrization(pts, gbs::KnotsCalcMode::CHORD_LENGTH, true);
+    auto k_flat = gbs::build_simple_mult_flat_knots(u.front(), u.back(), 6, p);
+
+    // n_poles < p + 1 -> rejected on every entry point
+    ASSERT_THROW(gbs::approx(pts, p, p, u, true), std::length_error);            // dispatcher (fix_bound)
+    ASSERT_THROW(gbs::approx(pts, p, p, u, false), std::length_error);           // dispatcher (free)
+    ASSERT_THROW(gbs::approx(pts, p, p, gbs::KnotsCalcMode::CHORD_LENGTH), std::length_error); // public
+    ASSERT_THROW(gbs::approx_bound_fixed(pts, p, p, u, k_flat), std::length_error);
+
+    // n_poles > n_pts -> rejected on every entry point
+    size_t too_many = pts.size() + 1;
+    ASSERT_THROW(gbs::approx(pts, p, too_many, u, true), std::length_error);
+    ASSERT_THROW(gbs::approx(pts, p, too_many, u, false), std::length_error);
+
+    // a well-posed count still succeeds
+    ASSERT_NO_THROW(gbs::approx(pts, p, size_t{6}, u, true));
 }
 


### PR DESCRIPTION
**PR1 (correctness)** of the approximation audit — issue #65, epic #44.
Scope is correctness + guards only in `gbs/bscapprox.h` and `gbs/bssapprox.h`.
No perf work, no matrix-assembly/solver changes — those are PR2 (assembly),
PR3 (structured solve), PR4 (dedup), which follow this merge in series.

## `refine_approx` stop criteria

- **C1 (real bug)** — the average-deviation stop test was meaningless. `d_avg_ += d`
  lived *inside* `if (d > d_max_)`, so it accumulated only record-breaking distances
  before dividing by `pts.size()`; the `d_avg_ < d_avg` test compared garbage. It now
  sums the distance of **every** point, so `d_avg_` is the true mean deviation.
- **C2** — the max-deviation stop test ignored errors near a knot. `d_max_`/`u_max`
  were updated only when the worst point was "well inside" a span (`>0.33`), so if all
  large errors sat next to knots, `u_max < 0` → break, reporting convergence with the
  tolerance unmet. The two concerns are now **separated**:
  - `d_max_` / `d_avg_` track the true max/mean over **all** points → stop criterion;
  - `d_insert` / `u_max` pick **where** to insert the next knot.
  The `0.33` magic number is now the named, documented `min_span_fraction` (placement
  filter only — it must not influence the stop criterion).

## Guards (C3) — consistent rejection on every entry point

- **Curves:** a shared `check_approx_sizes` rejects `n_poles < p+1` (matching
  `check_curve`) **and** `n_poles > n_pts`, wired into `approx`, `approx_bound_fixed`,
  and the `fix_bound` dispatcher (before knot construction, where `n_poles < p+1` would
  otherwise underflow the `size_t` span count and OOB-write under `_GLIBCXX_ASSERTIONS`).
- **Surfaces:** `check_approx_sizes_surf` applies the analogous per-direction
  `n_poles_u < p+1` / `n_poles_v < q+1` and `n_poles > n_pts` checks to **both** the
  grid and constraint overloads (the grid one previously only checked `n_poles > n_pt`
  with a terse `"size error"`).

## Tests

- `refine_approx_honors_average_tolerance_C1` — average criterion binds; locks C1.
- `refine_approx_honors_max_tolerance_near_knots_C2` — localized-feature dataset whose
  worst residuals sit next to inserted knots; locks C2.
- `approx_rejects_illposed_pole_counts_C3` (curve) + `surf_approx_rejects_illposed_pole_counts_C3`
  (surface) — `n_poles < p+1` and `n_poles > n_pts` rejected consistently via `ASSERT_THROW`,
  valid configs still succeed.

Both C1 and C2 tests were verified to **fail against the original buggy loop** and pass
after the fix.

## Acceptance

- Stop criteria reflect the true avg/max deviation over all points; `0.33` named.
- Consistent `n_poles<p+1` / `n_poles>n_pts` rejection on curves **and** surfaces.
- Existing approx tests stay green (ran the approx-affected target set:
  `tests_bscapprox`, `tests_approx`, `tests_bssbuild`, `tests_foils`, `tests_curves`,
  `tests_bssurftools`, `tests_oi`, `tests_bsinterp`, `tests_bscbuild`, `tests_bssurf`,
  `tests_surface_derivatives`, `tests_topo`, `tests_knotsfunctions`, `tests_tojson` —
  all pass).

> Note: the airfoil `approx_refined` curve now lands at **28 poles** (was 23). This is
> the intended consequence of the fix — the corrected criterion honors the requested
> tolerance on **all** points (including near-knot ones) instead of stopping early on a
> partial subset. The existing deviation assertions (loose upper bounds) remain satisfied
> with margin.

Refs #65 (PR1), epic #44. PR2 (assembly) follows after merge.