### PR TITLE
perf(approx): banded one-pass assembly for approx_bound_fixed + surface fills (#65 PR2)

### DIFF
--- a/bench/APPROX_AUDIT.md
+++ b/bench/APPROX_AUDIT.md
@@ -86,6 +86,34 @@ kernel. Interpolation got `~N^6 → ~N²` from separability (#35); the *same*
 separable structure exists for grid **least squares** (`NᵀN = (MuᵀMu) ⊗ (MvᵀMv)`),
 so the analogous win is available here and unclaimed.
 
+### After PR 2 — banded assembly (A1, A2 landed)
+
+`approx_bound_fixed` and the surface fills (`fill_poles_matrix`, the `bss_constraint`
+overload) now assemble via the banded `fill_basis_row` (one `ders_basis_funs` A2.3
+pass per row/direction) instead of the recursive `basis_function`. Same solver,
+poles unchanged to ~1e-9 (locked by `approx_bound_fixed_banded_matches_recursive_A1`
+and `fill_poles_matrix_banded_matches_recursive_A2`).
+
+Curve, `n_points = 400`, `n_poles = 50`, vs degree (the A/B above, re-measured):
+
+| degree | banded ms | `approx_bound_fixed` ms | ratio |
+|--------|-----------|-------------------------|-------|
+| 1 | 2.59 | 2.38 | 0.92× |
+| 3 | 2.60 | 2.39 | 0.92× |
+| 5 | 2.60 | 2.38 | 0.91× |
+| 7 | 2.63 | 2.51 | 0.95× |
+| 9 | 2.61 | 2.39 | 0.92× |
+
+`approx_bound_fixed` is now **flat in degree** — the `~2^p` blow-up is gone
+(p9 was **18.74×**, now **0.92×**). Both paths are solve-dominated and equal up to
+the (now-identical) banded assembly cost.
+
+The surface grid total is still dominated by the dense `colPivHouseholderQr` solve,
+so its wall-clock vs N is essentially unchanged by this PR: the dense **fill** factor
+is removed (assembly is now `O(n_params·(p+1)(q+1))` rather than
+`O(n_params·np_u·np_v·2^{p+q})`), but the dense **solve** is the remaining cost and
+is PR 3's target (separable `(MuᵀMu) ⊗ (MvᵀMv)`).
+
 ## Findings
 
 ### A. Performance

--- a/bench/bench_approx.cpp
+++ b/bench/bench_approx.cpp
@@ -3,17 +3,18 @@
 // Curve : gbs::approx(pts, p, n_poles, u, fix_bound)
 //   fix_bound=false -> gbs::approx(...,k_flat)  : build_poles_matrix
 //                      (BANDED one-pass assembly, ders) + dense colPivHouseholderQr
-//   fix_bound=true  -> gbs::approx_bound_fixed  : DENSE assembly via the RECURSIVE
-//                      basis_function (~2^p) + dense colPivHouseholderQr
-//   => an A/B on the assembly kernel, same solver.
+//   fix_bound=true  -> gbs::approx_bound_fixed  : also BANDED assembly via
+//                      fill_basis_row since PR2 (#65) + dense colPivHouseholderQr
+//   => post-PR2 both paths are banded: the A/B collapses to ~1.0 and is flat in
+//      degree (it used to read off the recursive ~2^p blow-up, now removed).
 //
 // Surface: gbs::approx(grid, ku, kv, u, v, p, q)  (bssapprox.h)
-//   fill_poles_matrix : DENSE Kronecker, (np_u*np_v) cols per row, each entry via
-//   the RECURSIVE basis_function + dense colPivHouseholderQr on a
-//   (nu*nv) x (np_u*np_v) matrix.
+//   fill_poles_matrix : BANDED tensor-product fill since PR2 (only the (p+1)(q+1)
+//   non-zero columns per row) + dense colPivHouseholderQr on a
+//   (nu*nv) x (np_u*np_v) matrix. The dense SOLVE is the remaining cost (PR3).
 //
 // We read off the scaling exponent (curve vs #points and vs degree; surface vs
-// grid side N) and the recursive-vs-banded assembly gap.
+// grid side N) and the recursive-vs-banded assembly gap (now closed for curves).
 
 #include <gbs/bscapprox.h>
 #include <gbs/bssapprox.h>

--- a/gbs/bscapprox.h
+++ b/gbs/bscapprox.h
@@ -72,26 +72,23 @@ namespace gbs
     {
         check_approx_sizes(n_poles, p, pts.size());
         auto n_params = int(u.size());
-        MatrixX<T> N(n_params-2, n_poles-2);
 
+        // Banded one-pass assembly (A2.3): each interior collocation row has only
+        // p+1 non-zero basis values (columns [span-p, span]); fill_basis_row writes
+        // exactly those via a single ders_basis_funs pass instead of n_poles
+        // recursive basis_function calls. We fill the full-width rows, then split off
+        // the two fixed boundary columns (poles P0 and P_{n-1}) into the RHS.
+        MatrixX<T> N_full(n_params - 2, n_poles);
+        N_full.setZero();
+        for (int i = 0; i < n_params - 2; i++)
+            fill_basis_row(N_full, Eigen::Index(i), u[i + 1], k_flat, p, size_t{0});
 
-        for (int i = 0; i < n_params-2; i++) // TODO check if matrix is row or col dominant
-        {
-            for (int j = 0; j < n_poles-2; j++)
-            {
-                    N(i , j) = basis_function(u[i+1], j+1, p, 0, k_flat);
-            }
-        }
+        MatrixX<T> N = N_full.middleCols(1, n_poles - 2);
+        auto Nbegin = N_full.col(0);
+        auto Nend = N_full.col(n_poles - 1);
 
         auto p_begin = pts.front();
         auto p_end = pts.back();
-        std::vector<T> Nbegin(n_params-2),Nend(n_params-2);
-        for (int i = 0; i < n_params-2; i++)
-        {
-            Nbegin[i] = basis_function(u[i+1], 0, p, 0, k_flat);
-            Nend[i] = basis_function(u[i+1], n_poles-1, p, 0, k_flat);
-        }
-
 
         // auto N_inv = N.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
         auto N_inv = N.colPivHouseholderQr();
@@ -104,7 +101,7 @@ namespace gbs
         {
             for (int i = 0; i < n_pt-2; i++)
             {
-                b(i) = pts[i+1][d] - p_begin[d] * Nbegin[i] - p_end[d] * Nend[i]; //Pas top au niveau de la localisation mémoire
+                b(i) = pts[i+1][d] - p_begin[d] * Nbegin(i) - p_end[d] * Nend(i); //Pas top au niveau de la localisation mémoire
             }
 
             auto x = N_inv.solve(b);

--- a/gbs/bssapprox.h
+++ b/gbs/bssapprox.h
@@ -56,16 +56,42 @@ namespace gbs
         auto n_poles = n * m;
         check_approx_sizes_surf(n, p, m, q, n_constraints);
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> N(n_constraints, n_poles);
-        for (int k = 0; k < n_constraints; k++) // Eigen::ColMajor is default
+        // Banded tensor-product assembly: a constraint row is the outer product of
+        // the two 1-D basis (derivative) bands at (u, v). Only the (p+1)(q+1) columns
+        // in the joint support are non-zero, so we evaluate each 1-D band once
+        // (one A2.3 pass) and write only that block instead of a recursive
+        // basis_function over all n*m columns of every row.
+        N.setZero();
+        for (size_t k = 0; k < n_constraints; k++) // Eigen::ColMajor is default
         {
             auto [u, v, x, du, dv] = Q[k];
-            for (int j{}; j < m; j++)
+            if (du > p || dv > q)
+                continue; // derivative order above degree => row is identically zero
+
+            const size_t span_u = find_span(n, p, u, k_flat_u) - k_flat_u.begin();
+            const size_t imin = (span_u >= p) ? span_u - p : 0;
+            const size_t icnt = (imin + p < n) ? p + 1 : n - imin;
+            const size_t span_v = find_span(m, q, v, k_flat_v) - k_flat_v.begin();
+            const size_t jmin = (span_v >= q) ? span_v - q : 0;
+            const size_t jcnt = (jmin + q < m) ? q + 1 : m - jmin;
+
+            const bool on_stack = (p <= bspline_stack_max_degree) && (q <= bspline_stack_max_degree);
+            T Nu[bspline_stack_max_degree + 1];
+            T Nv[bspline_stack_max_degree + 1];
+            if (on_stack)
             {
-                for (int i{}; i < n; i++)
+                basis_ders(span_u, p, du, u, k_flat_u, Nu);
+                basis_ders(span_v, q, dv, v, k_flat_v, Nv);
+            }
+            for (size_t jb = 0; jb < jcnt; ++jb)
+            {
+                size_t j = jmin + jb;
+                T Nvj = on_stack ? Nv[jb] : basis_function(v, j, q, dv, k_flat_v);
+                for (size_t ib = 0; ib < icnt; ++ib)
                 {
-                    auto l = i + n * j;
-                    N(k, l) = basis_function(u, i, p, du, k_flat_u) *
-                              basis_function(v, j, q, dv, k_flat_v);
+                    size_t i = imin + ib;
+                    T Nui = on_stack ? Nu[ib] : basis_function(u, i, p, du, k_flat_u);
+                    N(Eigen::Index(k), Eigen::Index(i + n * j)) = Nui * Nvj;
                 }
             }
         }

--- a/gbs/bssinterp.h
+++ b/gbs/bssinterp.h
@@ -52,21 +52,50 @@ namespace gbs
     {
         auto n_params_u = u.size();
         auto n_params_v = v.size();
-        auto n_poles_u = k_flat_u.size() - (p+1); 
-        auto n_poles_v = k_flat_v.size() - (q+1); 
-        size_t iRow, iCol;
+        auto n_poles_u = k_flat_u.size() - (p+1);
+        auto n_poles_v = k_flat_v.size() - (q+1);
+
+        // Banded tensor-product assembly. A grid collocation row N(iRow,*) is the
+        // outer product of the two 1-D basis bands at (u[iu], v[iv]); only the
+        // (p+1)(q+1) columns in [span_u-p, span_u] x [span_v-q, span_v] are non-zero.
+        // We evaluate each 1-D band once (fill_basis_row -> single A2.3 pass) and
+        // write only the non-zero block, instead of a recursive basis_function for
+        // every one of the n_poles_u*n_poles_v columns of every row.
+        N.setZero();
+        MatrixX<T> Mu(n_params_u, n_poles_u);
+        Mu.setZero();
+        for (size_t iu = 0; iu < n_params_u; ++iu)
+            fill_basis_row(Mu, Eigen::Index(iu), u[iu], k_flat_u, p, size_t{0});
+        MatrixX<T> Mv(n_params_v, n_poles_v);
+        Mv.setZero();
+        for (size_t iv = 0; iv < n_params_v; ++iv)
+            fill_basis_row(Mv, Eigen::Index(iv), v[iv], k_flat_v, q, size_t{0});
+
+        // First non-zero column and band width for a parameter (its support).
+        auto band = [](T x, const std::vector<T> &k, size_t deg, size_t np)
+        {
+            size_t span = find_span(np, deg, x, k) - k.begin();
+            size_t i_min = (span >= deg) ? span - deg : 0;
+            size_t cnt = (i_min + deg < np) ? deg + 1 : np - i_min;
+            return std::pair<size_t, size_t>{i_min, cnt};
+        };
+
         for (size_t iv = 0; iv < n_params_v; iv++)
         {
+            auto [jmin, jcnt] = band(v[iv], k_flat_v, q, n_poles_v);
             for (size_t iu = 0; iu < n_params_u; iu++)
             {
-                iRow = iu + n_params_u * iv;
-                for (size_t j = 0; j < n_poles_v; j++)
+                auto [imin, icnt] = band(u[iu], k_flat_u, p, n_poles_u);
+                size_t iRow = iu + n_params_u * iv;
+                for (size_t jb = 0; jb < jcnt; ++jb)
                 {
-                    auto Nv = basis_function(v[iv], std::next(k_flat_v.begin(), j), q, k_flat_v.end());
-                    for (size_t i = 0; i < n_poles_u; i++)
+                    size_t j = jmin + jb;
+                    T Nv = Mv(Eigen::Index(iv), Eigen::Index(j));
+                    for (size_t ib = 0; ib < icnt; ++ib)
                     {
-                        iCol = i + n_poles_u * j;
-                        N(iRow, iCol) = basis_function(u[iu], std::next(k_flat_u.begin(), i), p, k_flat_u.end()) * Nv;
+                        size_t i = imin + ib;
+                        N(Eigen::Index(iRow), Eigen::Index(i + n_poles_u * j)) =
+                            Mu(Eigen::Index(iu), Eigen::Index(i)) * Nv;
                     }
                 }
             }

--- a/tests/tests_bscapprox.cpp
+++ b/tests/tests_bscapprox.cpp
@@ -360,3 +360,48 @@ TEST(tests_bscapprox, approx_rejects_illposed_pole_counts_C3)
     ASSERT_NO_THROW(gbs::approx(pts, p, size_t{6}, u, true));
 }
 
+// A1 (assembly): approx_bound_fixed now assembles the collocation rows with the
+// banded one-pass fill_basis_row instead of the recursive basis_function. The
+// produced poles must match the original dense/recursive assembly to ~1e-9.
+TEST(tests_bscapprox, approx_bound_fixed_banded_matches_recursive_A1)
+{
+    using gbs::operator-;
+    auto pts = wavy_point_set(20);
+    size_t p = 3, n_poles = 8;
+    auto u = gbs::curve_parametrization(pts, gbs::KnotsCalcMode::CHORD_LENGTH, true);
+    auto k_flat = gbs::build_simple_mult_flat_knots(u.front(), u.back(), n_poles, p);
+
+    // Reference: the original DENSE assembly via the recursive basis_function,
+    // same endpoint-fixed least-squares solve.
+    int n_params = int(u.size());
+    gbs::MatrixX<double> N(n_params - 2, int(n_poles) - 2);
+    for (int i = 0; i < n_params - 2; ++i)
+        for (int j = 0; j < int(n_poles) - 2; ++j)
+            N(i, j) = gbs::basis_function(u[i + 1], size_t(j + 1), p, size_t{0}, k_flat);
+    std::vector<double> Nbegin(n_params - 2), Nend(n_params - 2);
+    for (int i = 0; i < n_params - 2; ++i)
+    {
+        Nbegin[i] = gbs::basis_function(u[i + 1], size_t{0}, p, size_t{0}, k_flat);
+        Nend[i]   = gbs::basis_function(u[i + 1], n_poles - 1, p, size_t{0}, k_flat);
+    }
+    auto qr = N.colPivHouseholderQr();
+    int n_pt = int(pts.size());
+    std::vector<std::array<double, 2>> poles_ref(n_poles);
+    gbs::VectorX<double> b(n_pt - 2);
+    for (int d = 0; d < 2; ++d)
+    {
+        for (int i = 0; i < n_pt - 2; ++i)
+            b(i) = pts[i + 1][d] - pts.front()[d] * Nbegin[i] - pts.back()[d] * Nend[i];
+        auto x = qr.solve(b);
+        for (int i = 1; i < int(n_poles) - 1; ++i)
+            poles_ref[i][d] = x(i - 1);
+    }
+    poles_ref.front() = pts.front();
+    poles_ref.back()  = pts.back();
+
+    auto crv = gbs::approx_bound_fixed(pts, p, n_poles, u, k_flat);
+    ASSERT_EQ(crv.poles().size(), poles_ref.size());
+    for (size_t i = 0; i < poles_ref.size(); ++i)
+        ASSERT_LT(gbs::norm(crv.poles()[i] - poles_ref[i]), 1e-9);
+}
+

--- a/tests/tests_bssurf.cpp
+++ b/tests/tests_bssurf.cpp
@@ -687,8 +687,56 @@ TEST(tests_bssurf, approx_constrained)
     std::vector<T> kv{0.,0.,0.,0.,1.,1.,1.,1.};
 
     auto srf = gbs::approx(Q,ku,kv,p,q);
+
+    // 16 constraints, 16 poles (4x4) -> square, so every constraint (point value
+    // for (du,dv)=(0,0), v-tangent for (0,1)) is satisfied to solver precision.
+    // This locks the banded, derivative-order tensor-product assembly (A2).
+    using gbs::operator-;
+    for (const auto &c : Q)
+    {
+        auto [cu, cv, cx, cdu, cdv] = c;
+        ASSERT_LT(gbs::norm(srf.value(cu, cv, cdu, cdv) - cx), 1e-8);
+    }
+
     if(PLOT_ON)
         gbs::plot(srf,pts);
+}
+
+// A2 (assembly): fill_poles_matrix now writes the (p+1)(q+1) non-zero band of each
+// tensor-product collocation row via fill_basis_row (one A2.3 pass per direction)
+// instead of a recursive basis_function for every column. With interior knots in
+// both directions (multiple spans), the banded matrix must equal the original
+// dense/recursive one to ~1e-12.
+TEST(tests_bssurf, fill_poles_matrix_banded_matches_recursive_A2)
+{
+    using T = double;
+    const size_t p = 3, q = 2;
+    std::vector<T> ku{0., 0., 0., 0., 0.3, 0.7, 1., 1., 1., 1.}; // n_poles_u = 6
+    std::vector<T> kv{0., 0., 0., 0.4, 1., 1., 1.};              // n_poles_v = 4
+    const size_t npu = ku.size() - (p + 1), npv = kv.size() - (q + 1);
+    std::vector<T> u{0.05, 0.2, 0.45, 0.6, 0.85, 0.95};
+    std::vector<T> v{0.1, 0.5, 0.8, 0.95};
+    const size_t nu = u.size(), nv = v.size();
+
+    gbs::MatrixX<T> N(nu * nv, npu * npv);
+    gbs::fill_poles_matrix(N, ku, kv, u, v, p, q);
+
+    gbs::MatrixX<T> Nref(nu * nv, npu * npv);
+    Nref.setZero();
+    for (size_t iv = 0; iv < nv; ++iv)
+        for (size_t iu = 0; iu < nu; ++iu)
+        {
+            size_t iRow = iu + nu * iv;
+            for (size_t j = 0; j < npv; ++j)
+            {
+                T Nvj = gbs::basis_function(v[iv], j, q, size_t{0}, kv);
+                for (size_t i = 0; i < npu; ++i)
+                    Nref(iRow, i + npu * j) =
+                        gbs::basis_function(u[iu], i, p, size_t{0}, ku) * Nvj;
+            }
+        }
+
+    ASSERT_LT((N - Nref).cwiseAbs().maxCoeff(), 1e-12);
 }
 
 // Grid (tensor-product) interpolation via the separable solver (issue #34, PR1):


### PR DESCRIPTION
**PR2 (assembly)** of the approximation audit — issue #65, epic #44. Follows PR1 (#67).
Same solver, same result (~1e-9); only the matrix **assembly kernel** changes. PR3
(structured solve) and PR4 (dedup) follow on the same files.

## A1 — curve `approx_bound_fixed`
Replaced the dense fill via the recursive `basis_function` (`~2^p` per row) with a
banded one-pass fill via `fill_basis_row` (one `ders_basis_funs` A2.3 pass; only the
`p+1` non-zero columns). The two fixed boundary columns (`P0`, `P_{n-1}`) are sliced
off the full-width rows into the RHS. This is the default high-level path
(`fix_bound=true`, the refine loop) — the one that carried the `~2^p` blow-up.

## A2 — surface fills
- **`fill_poles_matrix`** (`bssinterp.h`): banded tensor-product fill. Each grid row
  is the outer product of the two 1-D bands at `(u[iu], v[iv])`; only the
  `(p+1)(q+1)` columns in the joint support are written (after `setZero`), via
  `fill_basis_row` per direction instead of a recursive `basis_function` over all
  `np_u*np_v` columns.
- **`approx(bss_constraint, …)`** (`bssapprox.h`): same banding with per-constraint
  derivative orders `(du, dv)`, one A2.3 pass per direction (recursive fallback for
  degree > `bspline_stack_max_degree`).

## Bench
`approx_bound_fixed` is now **flat in degree** — the curve A/B `recursive/banded`
ratio at degree 9 went from **18.74×** to **~0.92×**:

| degree | banded ms | `approx_bound_fixed` ms | ratio |
|--------|-----------|-------------------------|-------|
| 3 | 2.60 | 2.39 | 0.92× |
| 7 | 2.63 | 2.51 | 0.95× |
| 9 | 2.61 | 2.39 | 0.92× |

The surface grid **total** is still dominated by the dense QR solve (PR3's target);
the dense *fill* factor is removed but masked by the solve in end-to-end timing.
`bench/bench_approx.cpp` header + `bench/APPROX_AUDIT.md` updated with an "after PR2"
section.

## Tests (equivalence locks)
- `approx_bound_fixed_banded_matches_recursive_A1` (curve): poles from the banded
  assembly match a recursive-assembly reference to **~1e-9**.
- `fill_poles_matrix_banded_matches_recursive_A2` (surface): the banded matrix equals
  the recursive dense matrix to **~1e-12**, with interior knots in both directions.
- `approx_constrained` strengthened to assert the (square) constrained fit satisfies
  every point/tangent constraint — locks the derivative-order banded fill.

## Acceptance
- Poles match the dense/recursive solver to ~1e-9 (locked by the two equivalence tests).
- Curve assembly flat in degree (p9 18.7× → ~0.92×).
- Surface dense-*fill* factor gone (assembly now `O(n_params·(p+1)(q+1))`); the dense
  *solve* remains and is PR3.
- All approx-affected targets green (`tests_bscapprox`, `tests_approx`, `tests_bssurf`,
  `tests_bssbuild`, `tests_foils`, `tests_curves`, `tests_bssurftools`, `tests_oi`,
  `tests_bsinterp`, `tests_bscbuild`, `tests_surface_derivatives`, `tests_topo`,
  `tests_knotsfunctions`, `tests_tojson`, `tests_surfaces_shapping`).

Refs #65 (PR2), epic #44. PR3 (structured solve) follows after merge.