### PR TITLE
perf(approx): structured banded/separable least-squares solve (#65 PR3)

### DIFF
--- a/bench/APPROX_AUDIT.md
+++ b/bench/APPROX_AUDIT.md
@@ -114,6 +114,52 @@ is removed (assembly is now `O(n_params·(p+1)(q+1))` rather than
 `O(n_params·np_u·np_v·2^{p+q})`), but the dense **solve** is the remaining cost and
 is PR 3's target (separable `(MuᵀMu) ⊗ (MvᵀMv)`).
 
+### After PR 3 — structured solve (A3 landed)
+
+The dense `colPivHouseholderQr` is replaced by the structured normal equations:
+- **Curve** — banded `NᵀN` (SPD) Cholesky: dense `LDLT` below `approx_sparse_threshold`
+  (= 100 points), sparse `SimplicialLDLT` (NaturalOrdering, band-preserving) above.
+  The `dim` components are batched into one factorization (A5). `O(n·p²)` — linear in
+  the number of points.
+- **Surface grid** — separable `Cu·P·Cv = Muᵀ Q Mv` with `Cu = MuᵀMu`, `Cv = MvᵀMv`
+  factored once each (two small 1-D `LDLT`s) instead of one dense QR on the full
+  Kronecker system.
+
+Poles match the dense QR least-squares minimizer to ~1e-9 (locked by
+`approx_plain_structured_matches_dense_qr_A3`, `surf_grid_separable_matches_dense_qr_A3`,
+and the bound-fixed `..._A1` test, which now compares the QR reference against the
+structured solve). Re-measured (same machine as the tables above):
+
+Curve, degree 3, `n_poles = n/4`, vs #points (total `approx()` ms):
+
+| n_points | dense QR (PR2) | structured (PR3) | speed-up |
+|----------|----------------|------------------|----------|
+| 100 | 0.45  | 0.05  | ~9× |
+| 200 | 1.81  | 0.12  | ~15× |
+| 400 | 10.5  | 0.32  | ~33× |
+| 800 | 72.1  | **1.04** | **~69×** |
+
+The dense path was super-linear (50→800 pts ≈ 1000×); the structured path is ~linear
+(≈ 69× for 16× the points).
+
+Surface grid, bidegree (3,3), `n_poles = (N/2)²`, vs grid side N (total `approx()` ms):
+
+| N | poles | dense QR (PR2) | separable (PR3) | speed-up |
+|---|-------|----------------|-----------------|----------|
+| 8  | 16  | 0.08  | 0.004 | ~20× |
+| 16 | 64  | 4.05  | 0.010 | ~400× |
+| 24 | 144 | 33.4  | 0.022 | ~1500× |
+| 32 | 256 | 166.8 | **0.039** | **~4300×** |
+
+The dense path was `~N⁶`-ish (N=16→32 ≈ 41×); the separable path is `~N²` (≈ 3.9× for
+×4 poles).
+
+**Not done in PR3 (A4):** `refine_approx` still rebuilds and re-factorizes from
+scratch each iteration. Each pass is now cheap (structured), so the from-scratch cost
+is small; a rank-structured update of the factorization for the single inserted knot
+is a further win left for later (the basis changes non-trivially under knot insertion,
+so it is not a simple low-rank update).
+
 ## Findings
 
 ### A. Performance

--- a/bench/bench_approx.cpp
+++ b/bench/bench_approx.cpp
@@ -1,20 +1,20 @@
 // Performance audit harness for B-spline least-squares APPROXIMATION.
 //
 // Curve : gbs::approx(pts, p, n_poles, u, fix_bound)
-//   fix_bound=false -> gbs::approx(...,k_flat)  : build_poles_matrix
-//                      (BANDED one-pass assembly, ders) + dense colPivHouseholderQr
-//   fix_bound=true  -> gbs::approx_bound_fixed  : also BANDED assembly via
-//                      fill_basis_row since PR2 (#65) + dense colPivHouseholderQr
-//   => post-PR2 both paths are banded: the A/B collapses to ~1.0 and is flat in
-//      degree (it used to read off the recursive ~2^p blow-up, now removed).
+//   fix_bound=false -> gbs::approx(...,k_flat)  : BANDED assembly (build_poles_matrix,
+//                      ders) + structured banded NᵀN Cholesky since PR3 (#65)
+//   fix_bound=true  -> gbs::approx_bound_fixed  : BANDED assembly (fill_basis_row,
+//                      PR2) + the same structured solve (PR3)
+//   => post-PR3 both paths are banded assembly + banded normal-equations Cholesky:
+//      flat in degree and ~linear in #points (was dense QR, super-linear).
 //
 // Surface: gbs::approx(grid, ku, kv, u, v, p, q)  (bssapprox.h)
-//   fill_poles_matrix : BANDED tensor-product fill since PR2 (only the (p+1)(q+1)
-//   non-zero columns per row) + dense colPivHouseholderQr on a
-//   (nu*nv) x (np_u*np_v) matrix. The dense SOLVE is the remaining cost (PR3).
+//   BANDED tensor-product fill (PR2) + separable normal-equations solve since PR3
+//   (Cu·P·Cv = Muᵀ Q Mv, two small 1-D LDLTs) instead of a dense colPivHouseholderQr
+//   on the (nu*nv) x (np_u*np_v) Kronecker system => ~N² instead of ~N⁶.
 //
 // We read off the scaling exponent (curve vs #points and vs degree; surface vs
-// grid side N) and the recursive-vs-banded assembly gap (now closed for curves).
+// grid side N). The recursive/dense gaps are now closed (PR2 assembly, PR3 solve).
 
 #include <gbs/bscapprox.h>
 #include <gbs/bssapprox.h>

--- a/gbs/bscapprox.h
+++ b/gbs/bscapprox.h
@@ -3,11 +3,40 @@
 #include <string>
 #include <stdexcept>
 #include <Eigen/Dense>
+#include <Eigen/SparseCore>
+#include <Eigen/SparseCholesky>
 #include <gbs/bssinterp.h>
 #include <gbs/bscanalysis.h>
 
 namespace gbs
 {
+    // Below this many parameters a dense normal-equations LDLT beats the sparse
+    // path (SimplicialLDLT setup dominates for small systems); above it the banded
+    // collocation sparsity (p+1 non-zeros per row, sorted params + simple knots)
+    // makes the sparse Cholesky ~O(n*p^2) instead of the dense O(n*n_poles^2) QR.
+    inline constexpr Eigen::Index approx_sparse_threshold = 100;
+
+    // Least-squares pole solve for a banded collocation system through the normal
+    // equations C = NᵀN (SPD, banded). This is the book's global LS (A9.6,
+    // Eq. 9.63-9.67): (NᵀN) P = Nᵀ Q, Cholesky-solved. The dense colPivHouseholderQr
+    // it replaces is better conditioned but O(n*n_poles^2); the banded Cholesky is
+    // ~O(n*p^2) -> linear in the number of points (#37/#39 analog for approximation).
+    // All `dim` right-hand sides (columns of B) are solved with one factorization.
+    template <typename T>
+    auto solve_approx_banded(const MatrixX<T> &N, const MatrixX<T> &B) -> MatrixX<T>
+    {
+        const MatrixX<T> rhs = N.transpose() * B;
+        if (N.rows() < approx_sparse_threshold)
+        {
+            const MatrixX<T> C = N.transpose() * N;
+            return C.ldlt().solve(rhs);
+        }
+        const Eigen::SparseMatrix<T> Ns = N.sparseView();
+        Eigen::SparseMatrix<T> C = (Ns.transpose() * Ns).pruned();
+        Eigen::SimplicialLDLT<Eigen::SparseMatrix<T>, Eigen::Lower, Eigen::NaturalOrdering<int>> solver;
+        solver.compute(C);
+        return solver.solve(rhs);
+    }
     /**
      * @brief Reject ill-posed approximation sizes, consistently for every point-set
      * entry point (curve overloads previously checked this in only one place).
@@ -90,27 +119,21 @@ namespace gbs
         auto p_begin = pts.front();
         auto p_end = pts.back();
 
-        // auto N_inv = N.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
-        auto N_inv = N.colPivHouseholderQr();
-
         auto n_pt = pts.size();
 
+        // Batched RHS: the fixed boundary poles are moved to the right-hand side,
+        // one column per spatial component, all solved with one factorization.
+        MatrixX<T> B(Eigen::Index(n_pt - 2), Eigen::Index(dim));
+        for (int d = 0; d < int(dim); d++)
+            for (int i = 0; i < int(n_pt) - 2; i++)
+                B(i, d) = pts[i + 1][d] - p_begin[d] * Nbegin(i) - p_end[d] * Nend(i);
+
+        const MatrixX<T> X = solve_approx_banded(N, B); // (n_poles-2) x dim
+
         std::vector<std::array<T, dim>> poles(n_poles);
-        VectorX<T> b(n_pt-2);
-        for (int d = 0; d < dim; d++)
-        {
-            for (int i = 0; i < n_pt-2; i++)
-            {
-                b(i) = pts[i+1][d] - p_begin[d] * Nbegin(i) - p_end[d] * Nend(i); //Pas top au niveau de la localisation mémoire
-            }
-
-            auto x = N_inv.solve(b);
-
-            for (int i = 1; i < n_poles - 1; i++)
-            {
-                poles[i][d] = x(i - 1);
-            }
-        }
+        for (int d = 0; d < int(dim); d++)
+            for (int i = 1; i < int(n_poles) - 1; i++)
+                poles[i][d] = X(i - 1, d);
         poles.front() = pts.front();
         poles.back() = pts.back();
 
@@ -135,27 +158,22 @@ namespace gbs
         MatrixX<T> N(u.size(), n_poles);
         build_poles_matrix<T, 1>(k_flat, u, p, n_poles, N);
 
-        // auto N_inv = N.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
-        auto N_inv = N.colPivHouseholderQr();
-
         auto n_pt = pts.size();
 
+        // Batched RHS: one column per spatial component, all solved with one
+        // factorization of the banded normal equations.
+        const Eigen::Index n_comp = Eigen::Index(dim);
+        MatrixX<T> B(Eigen::Index(n_pt), n_comp);
+        for (int d = 0; d < int(dim); d++)
+            for (int i = 0; i < int(n_pt); i++)
+                B(i, d) = pts[i][d];
+
+        const MatrixX<T> X = solve_approx_banded(N, B); // n_poles x dim
+
         std::vector<std::array<T, dim>> poles(n_poles);
-        VectorX<T> b(n_pt);
-        for (int d = 0; d < dim; d++)
-        {
-            for (int i = 0; i < n_pt; i++)
-            {
-                b(i) = pts[i][d]; //Pas top au niveau de la localisation mémoire
-            }
-
-            auto x = N_inv.solve(b);
-
-            for (int i = 0; i < n_poles; i++)
-            {
-                poles[i][d] = x(i);
-            }
-        }
+        for (int d = 0; d < int(dim); d++)
+            for (int i = 0; i < int(n_poles); i++)
+                poles[i][d] = X(i, d);
 
         return BSCurve<T,dim>(poles, k_flat, p);
     }

--- a/gbs/bssapprox.h
+++ b/gbs/bssapprox.h
@@ -42,9 +42,47 @@ namespace gbs
         auto n_poles_v = k_flat_v.size() - (q+1);
         auto n_poles = n_poles_u * n_poles_v;
         check_approx_sizes_surf(n_poles_u, p, n_poles_v, q, n_pt);
-        MatrixX<T> N(n_params_u*n_params_v, n_poles);
-        fill_poles_matrix(N,k_flat_u,k_flat_v,u,v,p,q);
-        return build_poles(N.colPivHouseholderQr(),Q);
+
+        // Separable least squares. The grid collocation matrix is the Kronecker
+        // product Mv (x) Mu, so its normal equations factor as
+        //   (MvᵀMv) (x) (MuᵀMu),  i.e.  Cu * P * Cv = Muᵀ Q Mv,
+        // with Cu = MuᵀMu (n_poles_u²) and Cv = MvᵀMv (n_poles_v²) the two small 1-D
+        // normal-equation matrices. We factor each once (SPD -> LDLT) and solve two
+        // sequences of 1-D solves instead of one dense O((nu*nv)*(np_u*np_v)^2) QR on
+        // the full Kronecker system (surface analog of the curve banded solve / #35).
+        // Poles and Q are stored U-first: index i + n_poles_u * j.
+        const Eigen::Index nau = Eigen::Index(n_params_u), nav = Eigen::Index(n_params_v);
+        const Eigen::Index npu = Eigen::Index(n_poles_u), npv = Eigen::Index(n_poles_v);
+
+        MatrixX<T> Mu(nau, npu);
+        Mu.setZero();
+        for (size_t iu = 0; iu < n_params_u; ++iu)
+            fill_basis_row(Mu, Eigen::Index(iu), u[iu], k_flat_u, p, size_t{0});
+        MatrixX<T> Mv(nav, npv);
+        Mv.setZero();
+        for (size_t iv = 0; iv < n_params_v; ++iv)
+            fill_basis_row(Mv, Eigen::Index(iv), v[iv], k_flat_v, q, size_t{0});
+
+        auto ldlt_u = (Mu.transpose() * Mu).ldlt();
+        auto ldlt_v = (Mv.transpose() * Mv).ldlt();
+
+        std::vector<std::array<T, dim>> poles(n_poles);
+        MatrixX<T> Qd(nau, nav);
+        for (int d = 0; d < int(dim); ++d)
+        {
+            for (size_t iv = 0; iv < n_params_v; ++iv)
+                for (size_t iu = 0; iu < n_params_u; ++iu)
+                    Qd(Eigen::Index(iu), Eigen::Index(iv)) = Q[iu + n_params_u * iv][d];
+
+            const MatrixX<T> M = Mu.transpose() * Qd * Mv;     // Muᵀ Q Mv (n_poles_u x n_poles_v)
+            const MatrixX<T> Y = ldlt_u.solve(M);              // Cu^{-1} M
+            const MatrixX<T> P = ldlt_v.solve(Y.transpose()).transpose(); // Y Cv^{-1}
+
+            for (size_t j = 0; j < n_poles_v; ++j)
+                for (size_t i = 0; i < n_poles_u; ++i)
+                    poles[i + n_poles_u * j][d] = P(Eigen::Index(i), Eigen::Index(j));
+        }
+        return poles;
     }
 
     template <typename T, size_t dim>

--- a/tests/tests_approx.cpp
+++ b/tests/tests_approx.cpp
@@ -92,3 +92,37 @@ TEST(tests_approx, surf_approx_rejects_illposed_pole_counts_C3)
     auto ku_ok = gbs::build_simple_mult_flat_knots(0., 1., size_t{4}, deg_u);
     ASSERT_NO_THROW(gbs::approx(points, ku_ok, kv_ok, u, v, deg_u, deg_v));
 }
+
+// A3 (structured solve): the grid approx now solves the separable normal equations
+// Cu * P * Cv = Muᵀ Q Mv (two small 1-D LDLT solves) instead of a dense
+// colPivHouseholderQr on the full (nu*nv) x (np_u*np_v) Kronecker system. With a
+// tall grid (more params than poles) and interior knots in both directions, the
+// poles must match the dense QR least-squares minimizer to ~1e-9.
+TEST(tests_approx, surf_grid_separable_matches_dense_qr_A3)
+{
+    const size_t p = 3, q = 2;
+    auto ku = gbs::build_simple_mult_flat_knots(0., 1., size_t{6}, p); // n_poles_u = 6
+    auto kv = gbs::build_simple_mult_flat_knots(0., 1., size_t{5}, q); // n_poles_v = 5
+    const size_t npu = 6, npv = 5;
+
+    const size_t nu = 14, nv = 11; // tall: 154 params >> 30 poles
+    std::vector<double> u(nu), v(nv);
+    for (size_t i = 0; i < nu; ++i) u[i] = i / (nu - 1.);
+    for (size_t j = 0; j < nv; ++j) v[j] = j / (nv - 1.);
+    std::vector<std::array<double, 3>> Q(nu * nv);
+    for (size_t j = 0; j < nv; ++j)
+        for (size_t i = 0; i < nu; ++i)
+            Q[i + nu * j] = {u[i], v[j], std::sin(2.0 * u[i]) * std::cos(1.7 * v[j])};
+
+    // Separable solver (under test).
+    auto poles = gbs::approx(Q, ku, kv, u, v, p, q);
+
+    // Dense QR reference: full Kronecker collocation matrix + rectangular QR.
+    gbs::MatrixX<double> N(Eigen::Index(nu * nv), Eigen::Index(npu * npv));
+    gbs::fill_poles_matrix(N, ku, kv, u, v, p, q);
+    auto poles_ref = gbs::build_poles(N.colPivHouseholderQr(), Q);
+
+    ASSERT_EQ(poles.size(), poles_ref.size());
+    for (size_t i = 0; i < poles.size(); ++i)
+        ASSERT_LT(gbs::norm(poles[i] - poles_ref[i]), 1e-9);
+}

--- a/tests/tests_bscapprox.cpp
+++ b/tests/tests_bscapprox.cpp
@@ -405,3 +405,35 @@ TEST(tests_bscapprox, approx_bound_fixed_banded_matches_recursive_A1)
         ASSERT_LT(gbs::norm(crv.poles()[i] - poles_ref[i]), 1e-9);
 }
 
+// A3 (structured solve): the plain curve approx now solves the banded normal
+// equations (NᵀN, SPD) via Cholesky instead of a dense colPivHouseholderQr on the
+// rectangular system. With 150 points it crosses approx_sparse_threshold, so the
+// SPARSE SimplicialLDLT branch runs. The poles must match the dense QR LS minimizer
+// to ~1e-9.
+TEST(tests_bscapprox, approx_plain_structured_matches_dense_qr_A3)
+{
+    using gbs::operator-;
+    auto pts = wavy_point_set(150); // > approx_sparse_threshold -> sparse Cholesky path
+    size_t p = 3, n_poles = 30;
+    auto u = gbs::curve_parametrization(pts, gbs::KnotsCalcMode::CHORD_LENGTH, true);
+    auto k_flat = gbs::build_simple_mult_flat_knots(u.front(), u.back(), n_poles, p);
+
+    // Dense QR reference on the rectangular collocation system.
+    gbs::MatrixX<double> N(Eigen::Index(u.size()), Eigen::Index(n_poles));
+    gbs::build_poles_matrix<double, 1>(k_flat, u, p, n_poles, N);
+    auto qr = N.colPivHouseholderQr();
+    std::vector<std::array<double, 2>> poles_ref(n_poles);
+    gbs::VectorX<double> b(Eigen::Index(pts.size()));
+    for (int d = 0; d < 2; ++d)
+    {
+        for (size_t i = 0; i < pts.size(); ++i) b(Eigen::Index(i)) = pts[i][d];
+        auto x = qr.solve(b);
+        for (size_t i = 0; i < n_poles; ++i) poles_ref[i][d] = x(Eigen::Index(i));
+    }
+
+    auto crv = gbs::approx(pts, p, n_poles, u, k_flat);
+    ASSERT_EQ(crv.poles().size(), poles_ref.size());
+    for (size_t i = 0; i < n_poles; ++i)
+        ASSERT_LT(gbs::norm(crv.poles()[i] - poles_ref[i]), 1e-9);
+}
+


### PR DESCRIPTION
**PR3 (structured solve)** of the approximation audit — issue #65, epic #44. Follows
PR1 (#67, correctness) and PR2 (#68, banded assembly). Same least-squares minimizer,
poles unchanged to ~1e-9; only the **solver structure** changes.

## A3 — curve (`bscapprox.h`)
New `solve_approx_banded` replaces the dense `colPivHouseholderQr` on the rectangular
collocation matrix with the banded normal equations `C = NᵀN` (SPD; book A9.6 /
Eq. 9.63–9.67):
- dense `LDLT` below `approx_sparse_threshold` (= 100 points),
- sparse `SimplicialLDLT` with `NaturalOrdering` (band-preserving) above — `~O(n·p²)`
  instead of `O(n·n_poles²)`, i.e. **linear in #points**.

**A5:** the `dim` right-hand sides are batched into one factorization (matrix RHS) in
both `approx` and `approx_bound_fixed`.

## A3 — surface grid (`bssapprox.h`)
The grid collocation matrix is the Kronecker product `Mv ⊗ Mu`, so its normal
equations separate: `Cu·P·Cv = Muᵀ Q Mv` with `Cu = MuᵀMu`, `Cv = MvᵀMv`. Each small
1-D matrix is factored once (`LDLT`) and solved as two sequences of 1-D solves,
instead of one dense QR on the full `(nu·nv) × (np_u·np_v)` system — **~N² instead of ~N⁶**.

## Measured (clang, -O3, double, dim=3)
| curve, deg 3, n_poles=n/4 | dense QR | structured | speed-up |
|---|---|---|---|
| 400 pts | 10.5 ms | 0.32 ms | ~33× |
| 800 pts | 72.1 ms | **1.04 ms** | **~69×** |

| surface grid (3,3), n_poles=(N/2)² | dense QR | separable | speed-up |
|---|---|---|---|
| N=16 (64 poles) | 4.05 ms | 0.010 ms | ~400× |
| N=32 (256 poles) | 166.8 ms | **0.039 ms** | **~4300×** |

Curve is now ~linear in #points (was super-linear); surface is ~N² (was ~N⁶).
`bench_approx.cpp` + `APPROX_AUDIT.md` updated with an "after PR3" section.

## Tests (equivalence locks, structured vs dense QR ~1e-9)
- `approx_plain_structured_matches_dense_qr_A3` — curve, 150 pts → exercises the
  **sparse** Cholesky branch.
- `surf_grid_separable_matches_dense_qr_A3` — tall grid, interior knots in both
  directions.
- `approx_bound_fixed_banded_matches_recursive_A1` (from PR2) now also locks the
  bound-fixed **structured** solve against the QR reference.

`refine_approx` output is unchanged (airfoil still 28 poles, `d_avg` 1.2e-8). All
approx-affected targets stay green (15 binaries incl. loft/foils/surfaces).

## Not done — A4
`refine_approx` still rebuilds and re-factorizes each iteration. Each pass is now
cheap (structured), so the from-scratch cost is small; a rank-structured update of
the factorization for the single inserted knot is left for later — knot insertion
changes the basis non-trivially, so it is **not** a simple low-rank update. Called
out in `APPROX_AUDIT.md`.

## Acceptance
- Poles match the dense solver to ~1e-9 (two new equivalence tests + the A1 test).
- Curve ~linear in #points; surface ~N²; bench before/after in the report.

Refs #65 (PR3), epic #44. PR4 (dedup/cleanup) follows after merge.