### PR TITLE
refactor(approx): remove dead code + dedup the curve overloads (#65 PR4)

### DIFF
--- a/gbs/bscapprox.h
+++ b/gbs/bscapprox.h
@@ -61,29 +61,11 @@ namespace gbs
                 ") must not exceed the number of points (" + std::to_string(n_pts) + ")");
         }
     }
-    template <typename T>
-    void removeRow(MatrixX<T> &matrix, unsigned int rowToRemove)
-    {
-        unsigned int numRows = matrix.rows() - 1;
-        unsigned int numCols = matrix.cols();
 
-        if (rowToRemove < numRows)
-            matrix.block(rowToRemove, 0, numRows - rowToRemove, numCols) = matrix.bottomRows(numRows - rowToRemove);
-
-        matrix.conservativeResize(numRows, numCols);
-    }
-
-    template <typename T>
-    void removeColumn(MatrixX<T> &matrix, unsigned int colToRemove)
-    {
-        unsigned int numRows = matrix.rows();
-        unsigned int numCols = matrix.cols() - 1;
-
-        if (colToRemove < numCols)
-            matrix.block(0, colToRemove, numRows, numCols - colToRemove) = matrix.rightCols(numCols - colToRemove);
-
-        matrix.conservativeResize(numRows, numCols);
-    }
+    // Default starting pole count for the auto-sized curve approximations: twice the
+    // degree. Heuristic shared by every overload that does not take n_poles
+    // explicitly (catalogued for the magic-constants sweep #38).
+    inline size_t default_n_poles(size_t p) { return p * 2; }
     /**
      * @brief Approximate a set of points with exact matchin at bounds
      * 
@@ -279,21 +261,18 @@ namespace gbs
             {
                 crv_refined = approx(pts, p, n_poles, u, knots);
             }
-            // std::cout << "d_avg: " << d_avg_ << ", d_max: " << d_max_ << ", u_max:" << u_max << std::endl;
             if (
                 (d_max_ < d_max && d_avg_ < d_avg)
                 || n_poles>= pts.size() - 5 // The idea of approximation id to get less pole tha  interpolation
                 )
                 break;
-            // std::cout << "n poles: " << crv_refined.poles().size() << ", n_flat: " << crv_refined.knotsFlats().size() << std::endl;
         }
         return crv_refined;
     }
     template <typename T, size_t dim>
     auto approx(const std::vector<std::array<T, dim>> &pts,const std::vector<T> &u, size_t p, bool fix_bound, T d_max = 1e-3, T d_avg= 1e-4, size_t n_max = 200) -> BSCurve<T, dim>
     {
-        auto n_poles = p * 2;
-        // auto n_poles = pts.size() / 5;
+        auto n_poles = default_n_poles(p);
         auto crv = approx(pts, p, n_poles, u, fix_bound);
         return refine_approx(pts,u,crv,fix_bound,d_max,d_avg,n_max);
     }
@@ -333,6 +312,28 @@ namespace gbs
     {
         auto u = curve_parametrization(pts, mode, adimensionnal);
         return approx(pts, p, n_poles, u, true);
+    }
+
+    // Sample a curve by deviation and return the point set together with its
+    // parameter vector. Shared by the deviation-driven Curve overloads below.
+    template <typename T, size_t dim>
+    auto sample_by_deviation(const Curve<T, dim> &crv, size_t np, T deviation)
+        -> std::pair<points_vector<T, dim>, std::vector<T>>
+    {
+        auto u_lst = deviation_based_params<T, dim>(crv, np, deviation);
+        points_vector<T, dim> pts = make_points(crv, u_lst);
+        std::vector<T> u{std::begin(u_lst), std::end(u_lst)};
+        return {std::move(pts), std::move(u)};
+    }
+
+    // Fit a starting bound-matched approximation with n_poles, then refine it to the
+    // requested tolerance (max deviation 10*tol). Shared tail of the Curve overloads.
+    template <typename T, size_t dim>
+    auto refine_from_points(const points_vector<T, dim> &pts, const std::vector<T> &u,
+                            size_t p, size_t n_poles, T tol) -> BSCurve<T, dim>
+    {
+        auto crv_approx = approx(pts, p, n_poles, u, true);
+        return refine_approx<T, dim>(pts, u, crv_approx, true, 10. * tol, tol);
     }
     /**
      * @brief Build a BSCurve approximation of crv, bounds approximation match crv's bounds.
@@ -396,12 +397,7 @@ namespace gbs
     auto approx(const Curve<T, dim> &crv, size_t p, size_t n_poles, std::vector<T> k_flat, T deviation, size_t np, size_t n_max_pts=5000)
     {
         auto u_lst = deviation_based_params<T, dim>(crv, np,deviation,n_max_pts);
-        std::vector<T> u(u_lst.size());
-        std::transform(
-            GBS_PAR_EXEC
-            u_lst.begin(),u_lst.end(),u.begin(),
-            [](const auto &u_){return u_;}
-        );
+        std::vector<T> u{std::begin(u_lst), std::end(u_lst)};
         auto pts = make_points(crv,u_lst);
         return approx_bound_fixed<T,dim>(pts,p,n_poles,u,k_flat);
     }
@@ -420,12 +416,8 @@ namespace gbs
     template <typename T, size_t dim>
     auto approx(const Curve<T,dim> &crv, T deviation,T tol, size_t p, size_t np = 30) -> BSCurve<T, dim>
     {
-        auto u_lst = deviation_based_params<T, dim>(crv, np,deviation);
-        auto pts = make_points(crv,u_lst);
-        size_t n_poles = std::max<size_t>(np / 3, p+1 );
-        std::vector<T> u{ std::begin(u_lst), std::end(u_lst) };
-        auto crv_approx = approx(pts, p, n_poles, u, true);
-        return refine_approx<T,dim>(pts,u,crv_approx,true,10.*tol,tol);
+        auto [pts, u] = sample_by_deviation(crv, np, deviation);
+        return refine_from_points(pts, u, p, std::max<size_t>(np / 3, p + 1), tol);
     }
     /**
      * @brief Approximate curve respecting original curve's parametrization
@@ -442,11 +434,8 @@ namespace gbs
     template <typename T, size_t dim>
     auto approx(const Curve<T,dim> &crv, T deviation,T tol, size_t p, size_t n_poles, size_t np) -> BSCurve<T, dim>
     {
-        auto u_lst = deviation_based_params<T, dim>(crv, np,deviation);
-        auto pts = make_points(crv,u_lst);
-        std::vector<T> u{ std::begin(u_lst), std::end(u_lst) };
-        auto crv_approx = approx(pts, p, n_poles, u, true);
-        return refine_approx<T,dim>(pts,u,crv_approx,true,10.*tol,tol);
+        auto [pts, u] = sample_by_deviation(crv, np, deviation);
+        return refine_from_points(pts, u, p, n_poles, tol);
     }
     /**
      * @brief Approximate curve respecting original curve's parametrization between params u1 and u2
@@ -465,12 +454,10 @@ namespace gbs
     template <typename T, size_t dim>
     auto approx(const Curve<T,dim> &crv, T u1, T u2, T deviation,T tol, size_t p, size_t np = 30) -> BSCurve<T, dim>
     {
-        auto u_lst = deviation_based_params<T, dim>(crv, np,deviation);
-        auto pts = make_points(crv,u_lst);
-        auto n_poles = p * 2;
-        std::vector<T> u{ std::begin(u_lst), std::end(u_lst) };
-        auto crv_approx = approx(pts, p, n_poles, u, true);
-        return refine_approx<T,dim>(pts,u,crv_approx,true,10.*tol,tol);
+        // NB: u1/u2 are currently not applied (the whole curve is sampled), matching
+        // the pre-existing behaviour; left as-is to keep this a pure refactor.
+        auto [pts, u] = sample_by_deviation(crv, np, deviation);
+        return refine_from_points(pts, u, p, default_n_poles(p), tol);
     }
 
     template <typename T, size_t dim>
@@ -483,8 +470,7 @@ namespace gbs
         size_t np = 30
         ) -> BSCurve<T, dim>
     {
-        auto u_lst = deviation_based_params<T, dim>(crv, np,deviation);
-        auto pts = make_points(crv,u_lst);
+        auto [pts, u] = sample_by_deviation(crv, np, deviation);
         std::transform(
             GBS_PAR_EXEC
             pts.begin(),
@@ -492,10 +478,7 @@ namespace gbs
             pts.begin(),
             trf_func
         );
-        auto n_poles = p * 2;
-        std::vector<T> u{ std::begin(u_lst), std::end(u_lst) };
-        auto crv_approx = approx(pts, p, n_poles, u, true);
-        return refine_approx<T,dim>(pts,u,crv_approx,true,10.*tol,tol);
+        return refine_from_points(pts, u, p, default_n_poles(p), tol);
     }
 
     /**
@@ -513,7 +496,7 @@ namespace gbs
     {
         auto u_lst = uniform_distrib_params<T, dim>(crv, np);
         auto pts = make_points(crv,u_lst);
-        auto n_poles = p * 2;
+        auto n_poles = default_n_poles(p);
         std::vector<T> u{ std::begin(u_lst), std::end(u_lst) };
         return approx(pts, p, n_poles, u, true);
     }

--- a/tests/tests_bscapprox.cpp
+++ b/tests/tests_bscapprox.cpp
@@ -437,3 +437,40 @@ TEST(tests_bscapprox, approx_plain_structured_matches_dense_qr_A3)
         ASSERT_LT(gbs::norm(crv.poles()[i] - poles_ref[i]), 1e-9);
 }
 
+// PR4 dedup: the deviation-driven Curve overloads now share sample_by_deviation /
+// refine_from_points. These overloads had no in-repo callers; this exercises each so
+// the refactor (and their default n_poles paths) is actually covered. Each must
+// preserve the source curve's bounds and approximate it within tolerance.
+TEST(tests_bscapprox, curve_approx_overloads_smoke_PR4)
+{
+    using gbs::operator-;
+    std::vector<double> k = {0., 0., 0., 0., 0.5, 1., 1., 1., 1.};
+    std::vector<std::array<double, 3>> poles =
+        {{0, 0, 0}, {1, 2, 0}, {2, -1, 1}, {3, 1, 2}, {4, 0, 1}};
+    size_t p = 3;
+    gbs::BSCurve<double, 3> crv(poles, k, p);
+
+    const double deviation = 0.01, tol = 1.e-5;
+    const size_t np = 60;
+
+    auto check = [&](const gbs::BSCurve<double, 3> &a, double max_dev)
+    {
+        ASSERT_DOUBLE_EQ(crv.bounds()[0], a.bounds()[0]);
+        ASSERT_DOUBLE_EQ(crv.bounds()[1], a.bounds()[1]);
+        auto us = gbs::deviation_based_params(crv, np, deviation);
+        for (auto u_ : us)
+            ASSERT_LT(gbs::norm(crv(u_) - a(u_)), max_dev);
+    };
+
+    // 443: explicit n_poles, refined to tol.
+    check(gbs::approx(crv, deviation, tol, p, size_t{8}, np), 1.e-3);
+    // 466: (u1,u2) overload (whole curve sampled), default n_poles, refined to tol.
+    check(gbs::approx(crv, crv.bounds()[0], crv.bounds()[1], deviation, tol, p, np), 1.e-3);
+    // 477: per-point transform (identity here), default n_poles, refined to tol.
+    std::function<std::array<double, 3>(const std::array<double, 3> &)> identity =
+        [](const std::array<double, 3> &x) { return x; };
+    check(gbs::approx(crv, identity, deviation, tol, p, np), 1.e-3);
+    // 512: uniformly sampled, no refine (coarser) -> bounds preserved, loose deviation.
+    check(gbs::approx(crv, p, np), 1.e-1);
+}
+


### PR DESCRIPTION
**PR4 (dedup/cleanup)** of the approximation audit — issue #65, epic #44. Final PR of
the series, after PR1 (#67), PR2 (#68), PR3 (#69). **Pure refactor: no behaviour
change, no public overload removed.**

## D1 — dead code
Removed `removeRow` / `removeColumn` (used nowhere; `O(n²)` `conservativeResize`).

## D2 — commented dead code
Removed the commented `std::cout` debug lines in `refine_approx` and the dead
`// auto n_poles = pts.size()/5` alternative.

## E1 — dedup the `Curve` overloads
The deviation-driven `approx(crv, …)` overloads repeated the same six lines. They now
delegate to two shared helpers:
- `sample_by_deviation` — `deviation_based_params → make_points → u vector`,
- `refine_from_points` — fit a bound-matched start, then refine to `10*tol / tol`.

Public signatures are **unchanged** (API kept stable; only the bodies are deduped —
removing the overloads would break callers). Also simplified an identity
`std::transform` (used only to copy `u_lst`) to a direct range construction.

## E3 — constants
Named the repeated `n_poles = p*2` default as `default_n_poles(p)`. The rest of the
approx constants are left for the dedicated magic-constants sweep **#38** (which runs
last), as planned.

## E2 — already done
Consolidating surface assembly onto the shared banded helpers landed in PR2/PR3: the
grid approx uses the separable solver and no longer duplicates `fill_poles_matrix`.

## Tests
`curve_approx_overloads_smoke_PR4` exercises the `Curve` overloads that had **no
in-repo callers** (explicit-`n_poles`, `(u1,u2)`, per-point-transform, uniform): each
preserves the source bounds and approximates within tolerance. They were previously
uncovered — this both locks the refactor and closes the coverage gap. The `(u1,u2)`
overload still samples the whole curve (`u1/u2` unused) exactly as before, preserved
with an `NB` comment (not "fixed" here — that would be a behaviour change).

All 15 approx-affected targets stay green.

Refs #65 (PR4), epic #44. This completes the #65 approximation series
(correctness → assembly → structured solve → dedup).