### PR TITLE
fix(loft): default skin-direction params to averaged chord-length (#71)

### DIFF
--- a/gbs/loft/loftBase.h
+++ b/gbs/loft/loftBase.h
@@ -159,17 +159,71 @@ namespace gbs{
         return std::make_tuple(poles, flat_u, flat_v, p);
     }
 
+    /**
+     * Skin-direction (`v`) parameters for a loft, computed as the **averaged
+     * chord-length** parameters over the section pole rows — *The NURBS Book*
+     * §10.3 / Eq 10.8. Each aligned u-pole row is parametrized by chord length
+     * and normalized to [0, 1], then the rows are averaged. This mirrors the
+     * spine loft's `get_v_aligned_poles` so both loft routes share one
+     * parametrization law.
+     *
+     * `curves_info` must already be **compatible** (same pole count per
+     * section), i.e. unified. For rational input the poles are homogeneous, as
+     * everywhere else in the loft path.
+     *
+     * Robustness: a fully degenerate row (coincident poles across all sections,
+     * zero chord length) carries no parametrization information and is skipped
+     * rather than dividing by zero; if every row is degenerate the parameters
+     * fall back to uniform spacing.
+     *
+     * @return The `n_sections` parameters in [0, 1] (first 0, last 1).
+     */
+    template <std::floating_point T, size_t dim>
+    auto loft_averaged_params(const std::vector<BSCurveInfo<T, dim>> &curves_info,
+                              KnotsCalcMode mode = KnotsCalcMode::CHORD_LENGTH) -> std::vector<T>
+    {
+        const size_t nv = curves_info.size();                      // sections (v)
+        const size_t nu = std::get<0>(curves_info.front()).size(); // poles per section (u)
+
+        std::vector<T> v(nv, T{0});
+        std::vector<std::array<T, dim>> row(nv);
+        size_t contributing = 0;
+        for (size_t i = 0; i < nu; ++i)
+        {
+            for (size_t j = 0; j < nv; ++j)
+                row[j] = std::get<0>(curves_info[j])[i];
+            // Raw cumulative chord length down the sections for this pole row.
+            const auto params_i = curve_parametrization(row, mode, false);
+            const T total = params_i.back();
+            if (total <= T{0})
+                continue; // coincident-pole row — no parametrization information
+            for (size_t j = 0; j < nv; ++j)
+                v[j] += params_i[j] / total; // per-row normalization to [0, 1]
+            ++contributing;
+        }
+        if (contributing == 0)
+            return make_range(T{}, T{1}, nv); // all rows degenerate -> uniform
+        for (auto &vj : v)
+            vj /= T(contributing);
+        return v;
+    }
+
     template <std::floating_point T, size_t dim>
     auto loft(std::vector<BSCurveInfo<T, dim>> &curves_info, size_t q_max)
     {
-        // TODO: Compute an optimal parametrization
+        // Make the sections compatible first, then derive the skin-direction
+        // parameters as the NURBS Book §10.3 averaged chord-length law over the
+        // aligned pole rows (Eq 10.8) instead of a uniform spacing (#71).
+        unify_degree(curves_info);
+        unify_knots(curves_info);
+
+        auto v = loft_averaged_params<T, dim>(curves_info);
         auto n_curves = curves_info.size();
-        auto v = make_range(T{}, T{1}, n_curves);
         auto q = std::min(q_max, n_curves-1);
         // Build a simple multiple flat knot vector in the 'v' direction
         auto flat_v = build_simple_mult_flat_knots(v, q);
 
-        // Delegate to the main loft function to create the lofted surface
+        // curves_info is already unified; the inner loft's unify is a no-op.
         auto [poles, flat_u, p] = loft(curves_info, v, flat_v, q);
         return std::make_tuple(poles, flat_u, flat_v, p, q);
     }

--- a/tests/tests_bssbuild.cpp
+++ b/tests/tests_bssbuild.cpp
@@ -147,6 +147,43 @@ TEST(tests_bssbuild, loft)
         gbs::plot(s,c1,c2,c3);
 }
 
+// Regression for #71: the generic loft(curves, q_max) must derive the
+// skin-direction (v) parameters from the NURBS Book §10.3 averaged chord-length
+// law (Eq 10.8), NOT a uniform spacing. Three identical sections translated
+// along z by UNEVEN amounts (z = 0, 1, 4) give per-row chord distances 1 and 3
+// (total 4), hence averaged params [0, 0.25, 1], not the uniform [0, 0.5, 1].
+TEST(tests_bssbuild, loft_averaged_chord_param_71)
+{
+    using gbs::BSCurve3d_d;
+    size_t p = 2;
+    std::vector<double> k = {0., 0., 0., 0.5, 1., 1., 1.};
+    auto make_section = [&](double z) {
+        gbs::points_vector_3d_d poles = {
+            {0., 0., z}, {1., 2., z}, {2., 2., z}, {3., 0., z}};
+        return BSCurve3d_d(poles, k, p);
+    };
+    auto c0 = make_section(0.);
+    auto c1 = make_section(1.);
+    auto c2 = make_section(4.);
+
+    // Unit: averaged chord-length parameters over the aligned pole rows.
+    std::list<BSCurve3d_d> sections{c0, c1, c2};
+    auto curves_info = gbs::get_bs_curves_info<double, 3>(sections.begin(), sections.end());
+    auto v = gbs::loft_averaged_params<double, 3>(curves_info);
+    ASSERT_EQ(v.size(), 3u);
+    ASSERT_NEAR(v[0], 0.00, 1e-12);
+    ASSERT_NEAR(v[1], 0.25, 1e-12); // chord-length, NOT the uniform 0.5
+    ASSERT_NEAR(v[2], 1.00, 1e-12);
+
+    // End-to-end: an interpolating loft passes through the middle section at its
+    // averaged-chord parameter v = 0.25 (it would be v = 0.5 under uniform).
+    auto s = gbs::loft(std::list<BSCurve3d_d>{c0, c1, c2}, 2);
+    for (double u : {0.0, 0.25, 0.5, 0.75, 1.0})
+        ASSERT_NEAR(gbs::distance(s(u, 0.25), c1(u)), 0., 1e-9);
+    // ...and it must NOT interpolate the middle section at the uniform v = 0.5.
+    ASSERT_GT(gbs::distance(s(0.5, 0.5), c1(0.5)), 1e-3);
+}
+
 TEST(tests_bssbuild, loft_u)
 {
     size_t p = 2;


### PR DESCRIPTION
## Summary

The generic `loft(curves_info, q_max)` (`gbs/loft/loftBase.h`) built its
skin-direction (`v`) parameters with a uniform `make_range`, contradicting
*The NURBS Book* §10.3, which prescribes **averaged chord-length** parameters
(Eq 9.5/9.6 averaged over the section pole rows, then Eq 9.8 knot averaging).
On unevenly-spaced sections the uniform mapping distorts the parametrization
(uneven iso-`v`, worse fairing and downstream evaluation/offsetting). This is a
quality deviation, not a correctness bug — the surface still interpolates every
section.

## Change

- Add `loft_averaged_params()`: chord-length parametrization per aligned u-pole
  row (reusing the existing `curve_parametrization`), normalized to `[0, 1]` and
  averaged across rows — the **same law the spine loft already applies** in
  `get_v_aligned_poles` (`bssbuild.h`). No new math invented.
- Default the `q_max` overload to those averaged params and drop the stale
  `// TODO: Compute an optimal parametrization`.
- Degenerate (coincident-pole) rows carry no parametrization information and are
  skipped; an all-degenerate net falls back to uniform spacing.
- The explicit-`v` overloads are **untouched** — callers wanting uniform/custom
  `v` keep that path, so the public API is unchanged.

## Test

Regression in `tests/tests_bssbuild.cpp` (`loft_averaged_chord_param_71`) on
sections translated by uneven `z` (0, 1, 4):
- asserts the averaged-chord params are `[0, 0.25, 1]` (not the uniform `[0, 0.5, 1]`);
- the surface interpolates the middle section at `v = 0.25` (distance < 1e-9);
- and does **not** interpolate it at the uniform `v = 0.5`.

All loft-related test targets stay green (`tests_bssbuild`, `tests_tojson`,
`tests_bssurftools`, `tests_knotsfunctions`, `tests_foils`, `tests_bssurf`).

Closes #71. Refs #43, #44.