### PR TITLE
fix(occt): resolve the 2 OCCT 8 runtime divergences in gbs-occt (#47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ __pycache__/
 build/
 build-conda/
 build-cov/
+build-occt7/
+build-occt8/
+scratch/
 
 # Coverage instrumentation (GBS_COVERAGE / scripts/coverage.sh)
 *.profraw

--- a/gbs-occt/curvesbuild.cpp
+++ b/gbs-occt/curvesbuild.cpp
@@ -208,7 +208,11 @@ template <typename _InIt>
                                    1,                               //FirstPoint
                                    Standard_Integer(nb_csrt), //LastPoint
                                    TheConstraints,
-                                   5,                               // MaxDegree=14
+                                   8,                               // MaxDegree: must be >=6 for GeomAbs_C2.
+                                                                    // OCCT 8's AppDef_Variational::InitSmoothCriterion
+                                                                    // builds a PLib_JacobiPolynomial whose base needs
+                                                                    // WorkDegree >= 2*(NivConstr+1) = 6 for C2; the old
+                                                                    // value 5 made it throw "WorkDegree too small".
                                    Standard_Integer(nb_csrt), //MaxSegment=100,
                                 // 100,
                                    GeomAbs_C2,                      //Continuity=GeomAbs_C2,
@@ -297,7 +301,11 @@ template <typename _InIt>
                                    1,                               //FirstPoint
                                    Standard_Integer(nb_csrt), //LastPoint
                                    TheConstraints,
-                                   5,                               // MaxDegree=14
+                                   8,                               // MaxDegree: must be >=6 for GeomAbs_C2.
+                                                                    // OCCT 8's AppDef_Variational::InitSmoothCriterion
+                                                                    // builds a PLib_JacobiPolynomial whose base needs
+                                                                    // WorkDegree >= 2*(NivConstr+1) = 6 for C2; the old
+                                                                    // value 5 made it throw "WorkDegree too small".
                                    Standard_Integer(nb_csrt), //MaxSegment=100,
                                 // 100,
                                    GeomAbs_C2,                      //Continuity=GeomAbs_C2,

--- a/gbs-occt/tests/tests_curvesbuild.cpp
+++ b/gbs-occt/tests/tests_curvesbuild.cpp
@@ -5,12 +5,6 @@
 #include <vector>
 #include <chrono>
 #include <GeomAPI.hxx>
-#include <Standard_Version.hxx>
-
-// OCCT 8 a durci certaines validations d'approximation/construction de courbes.
-// Deux cas divergent a l'execution sous OCCT 8 (le build, lui, passe) ; ils
-// restent couverts par le job legacy OCCT 7. A corriger separement -> voir issue.
-#define GBS_OCCT8_KNOWN_DIVERGENCE (OCC_VERSION_HEX >= 0x080000)
 
 const double tol = 1e-10;
 const double tol_confusion = 1e-7;
@@ -55,9 +49,6 @@ TEST(tests_curvebuild, bsc_c1)
 
 TEST(tests_curvebuild, bscurve_c2_approx)
 {
-#if GBS_OCCT8_KNOWN_DIVERGENCE
-    GTEST_SKIP() << "OCCT 8: AppDef_Variational 'WorkDegree too small' (cf. issue)";
-#endif
     // auto c1 = occt_utils::bscurve_c2_approx<2>(
     //     {
     //         {0., 0.},
@@ -151,9 +142,6 @@ TEST(tests_bscurve, ctor)
 
 TEST(tests_bscurve, ctor_rational)
 {
-#if GBS_OCCT8_KNOWN_DIVERGENCE
-    GTEST_SKIP() << "OCCT 8: ctor BSpline rationnel divergent (cf. issue)";
-#endif
     std::vector<double> k = {0., 0., 0., 1, 2, 3, 4, 5., 5., 5.};
     std::vector<std::array<double, 3>> poles_nr =
         {
@@ -182,16 +170,22 @@ TEST(tests_bscurve, ctor_rational)
     auto c3_3d_dp = gbs::BSCurve3d_d(poles_nr, k, p);
     auto h_c1_3d_dp_ref = occt_utils::NURBSplineCurve(c1_3d_dp);
     auto h_c2_3d_dp_ref = occt_utils::BSplineCurve(c3_3d_dp);
+    // OCCT's DN(u, N) computes the N-th derivative and is only defined for
+    // N >= 1; the 0-th "derivative" is the curve value itself. OCCT 7 happened
+    // to accept DN(u, 0); OCCT 8 hardened it to raise Geom_UndefinedDerivative.
+    // Use Value() for order 0 (equivalent and version-agnostic).
+    auto occt_der = [](const Handle(Geom_Curve) &c, double u, int d) -> gp_Vec
+    { return d == 0 ? gp_Vec(c->Value(u).XYZ()) : c->DN(u, d); };
     for (int i = 0; i < n; i++)
     {
         auto u = k.front() + (k.back() - k.front()) * i / (n - 1.);
         for(auto d =0 ; d <=2 ; d++)
         {
             auto c1_3d_dp_cu1 = occt_utils::vector(c1_3d_dp.value(u, d));
-            auto c1_3d_dp_cu1_ref = h_c1_3d_dp_ref->DN(u, d);
+            auto c1_3d_dp_cu1_ref = occt_der(h_c1_3d_dp_ref, u, d);
             ASSERT_LT((c1_3d_dp_cu1_ref - c1_3d_dp_cu1).Magnitude(), tol);
             auto c2_3d_dp_cu1 = occt_utils::vector(c2_3d_dp.value(u, d));
-            auto c2_3d_dp_cu1_ref = h_c2_3d_dp_ref->DN(u, d);
+            auto c2_3d_dp_cu1_ref = occt_der(h_c2_3d_dp_ref, u, d);
             ASSERT_LT((c2_3d_dp_cu1_ref - c2_3d_dp_cu1).Magnitude(), tol);
         }
     }

--- a/scripts/occt_build_test.sh
+++ b/scripts/occt_build_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Build & run the gbs-occt tests against a local OCCT env, mirroring the CI
+# `occt` job: build target gbs-occt_tests, then run it.
+#
+# Usage:
+#   scripts/occt_build_test.sh [ENV_NAME] [BUILD_DIR] [DOCTEST_FILTER]
+# Defaults: ENV_NAME=gbs-occt8  BUILD_DIR=build-occt8  (no filter)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_NAME="${1:-gbs-occt8}"
+BUILD_DIR="${2:-${REPO_ROOT}/build-occt8}"
+FILTER="${3:-}"
+
+micromamba run -n "${ENV_NAME}" cmake --build "${BUILD_DIR}" --target gbs-occt_tests --parallel
+
+ENV_PREFIX="$(micromamba run -n "${ENV_NAME}" printenv CONDA_PREFIX)"
+RUN_DIR="${BUILD_DIR}/gbs-occt/tests"
+BIN="${RUN_DIR}/gbs-occt_tests"
+
+mkdir -p "${RUN_DIR}/tests/out"   # IGES writers use relative tests/out/ paths
+cd "${RUN_DIR}"
+if [[ -n "${FILTER}" ]]; then
+    LD_LIBRARY_PATH="${ENV_PREFIX}/lib:${LD_LIBRARY_PATH:-}" "${BIN}" -tc="${FILTER}"
+else
+    LD_LIBRARY_PATH="${ENV_PREFIX}/lib:${LD_LIBRARY_PATH:-}" "${BIN}"
+fi

--- a/scripts/occt_configure.sh
+++ b/scripts/occt_configure.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Configure a dedicated OCCT build tree using a local micromamba env that
+# mirrors the CI `occt` job (OCCT + clang + deps). Used to reproduce the
+# occt8 / occt7 CI jobs locally.
+#
+# Usage:
+#   scripts/occt_configure.sh [ENV_NAME] [BUILD_DIR]
+# Defaults: ENV_NAME=gbs-occt8  BUILD_DIR=build-occt8
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_NAME="${1:-gbs-occt8}"
+BUILD_DIR="${2:-${REPO_ROOT}/build-occt8}"
+
+micromamba run -n "${ENV_NAME}" cmake -B "${BUILD_DIR}" -S "${REPO_ROOT}" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DGBS_BUILD_TESTS=ON \
+    -DGBS_USE_OCCT_UTILS=ON \
+    -DGBS_USE_PYTHON_BINDINGS=OFF \
+    -DGBS_BUILD_STUBS=OFF \
+    -DGBS_USE_CUDA=OFF \
+    -DGBS_USE_MODULES=OFF \
+    -DGBS_BUILD_DOC=OFF \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++


### PR DESCRIPTION
## Summary
Fixes the two `gbs-occt` test cases that threw at runtime under **OCCT 8** (hardened validations) while passing under **OCCT 7**. They were previously skipped under OCCT 8 (`GTEST_SKIP` + `GBS_OCCT8_KNOWN_DIVERGENCE`). Both are fixed at the root and the skips removed.

### Case 1 — `tests_curvebuild.bscurve_c2_approx`
Exception: `WorkDegree too small for given ConstraintOrder`.

`AppDef_Variational` was constructed with `MaxDegree=5` for `GeomAbs_C2` continuity. Under OCCT 8, `AppDef_Variational::InitSmoothCriterion()` builds a `PLib_JacobiPolynomial` whose Jacobi base needs `WorkDegree >= 2*(NivConstr+1) = 6` for C2 — so `MaxDegree=5` is rejected (verified by probing `PLib_JacobiPolynomial(wd, GeomAbs_C2)`: throws for `wd<=5`, OK from `wd=6`). The backtrace confirms the throw originates in `InitSmoothCriterion` at construction, not in `Approximate()`.

Fix: raise `MaxDegree` to **8** in both the 2D and 3D overloads of `bscurve_c2_approx`. The constraint is a lower bound, so this is monotonic and safe for OCCT 7.

### Case 2 — `tests_bscurve.ctor_rational`
Exception with empty message — the issue hypothesized a stricter rational-ctor validation, but the constructor is actually fine. The real cause (isolated with gdb / a minimal repro) is a `Geom_UndefinedDerivative` raised by `Geom_Curve::DN(u, 0)` in the comparison loop.

`DN(u, N)` is the N-th derivative, defined only for `N >= 1`; the 0-th "derivative" is the curve value. OCCT 7 tolerated `DN(u, 0)` (equal to `Value(u)` to ~1e-15, verified on 7.9.3); OCCT 8 hardened it to throw.

Fix: use `Value()` for order 0 in the comparison loop (equivalent and version-agnostic).

### Cleanup
- Removed both `GTEST_SKIP` guards and the now-unused `GBS_OCCT8_KNOWN_DIVERGENCE` macro (+ its `Standard_Version.hxx` include).
- Added `scripts/occt_configure.sh` / `scripts/occt_build_test.sh` to reproduce the CI `occt8`/`occt7` jobs locally.

## Verification
Built and ran the full `gbs-occt_tests` suite locally against both OCCT majors (micromamba envs mirroring the CI `occt` job):

| OCCT | result |
|------|--------|
| 8.0.0 | **14/14 cases, 8032 assertions, 0 skipped** |
| 7.9.3 | **14/14 cases, 8032 assertions, 0 skipped** |

No regression on the other 12 cases.

Closes #47. Refs epic #44.