### PR TITLE
refactor: centralize tuning constants into gbs/gbsconstants.h (#38)

### DIFF
--- a/gbs/basisfunctions.ixx
+++ b/gbs/basisfunctions.ixx
@@ -135,11 +135,7 @@
         }
     }
 
-    // Largest B-spline degree the allocation-free evaluators handle on the
-    // stack. Real CAD/CAM degrees are well under this; beyond it the evaluators
-    // fall back to the (correct but slow) recursive basis_function so behaviour
-    // never silently breaks. Stack cost is O((max+1)^2) scalars.
-    inline constexpr size_t bspline_stack_max_degree = 24;
+    // bspline_stack_max_degree is defined in gbs/gbsconstants.h.
 
     /**
      * @brief Allocation-free B-spline basis functions (Piegl & Tiller A2.2).

--- a/gbs/bscanalysis.h
+++ b/gbs/bscanalysis.h
@@ -44,7 +44,7 @@ namespace gbs
             points.begin(),
             points.end(),
             [&](const auto &pnt) {
-                auto [res_u,res_d] = extrema_curve_point(crv, pnt, u0, 1e-6);
+                auto [res_u,res_d] = extrema_curve_point(crv, pnt, u0, extrema_tol<T>);
                 u0 = res_u;
                 if (res_d > d_max)
                 {
@@ -428,7 +428,7 @@ namespace gbs
  * @return A list of curve parameters with the refined deviation
  */
     template <typename T, size_t dim>
-    auto deviation_based_params(const Curve<T, dim> &crv, T u1, T u2, size_t n, T dev_max, size_t n_max_pts = 5000) -> std::list<T>
+    auto deviation_based_params(const Curve<T, dim> &crv, T u1, T u2, size_t n, T dev_max, size_t n_max_pts = approx_max_sample_points) -> std::list<T>
     {
 
         // Create initial list of parameters
@@ -485,7 +485,7 @@ namespace gbs
  * @return std::list<T> 
  */
     template <typename T, size_t dim>
-    auto deviation_based_params(const Curve<T, dim> &crv, size_t n, T dev_max, size_t n_max_pts=5000) -> std::list<T>
+    auto deviation_based_params(const Curve<T, dim> &crv, size_t n, T dev_max, size_t n_max_pts = approx_max_sample_points) -> std::list<T>
     {
 
         auto [u1, u2] = crv.bounds();
@@ -540,7 +540,7 @@ namespace gbs
      * @return points_vector<T,dim> 
      */
     template <typename T, size_t dim>
-    auto discretize(const Curve<T,dim> &crv, size_t n, T dev_max, size_t n_max_pts=5000) -> points_vector<T,dim>
+    auto discretize(const Curve<T,dim> &crv, size_t n, T dev_max, size_t n_max_pts = approx_max_sample_points) -> points_vector<T,dim>
     {
         auto u_lst = deviation_based_params<T, dim>(crv, n,dev_max,n_max_pts);
         // build points
@@ -559,7 +559,7 @@ namespace gbs
  * @return (points_vector<T,dim>, std::vector<T>) 
  */
     template <typename T, size_t dim>
-    auto discretize_with_params(const Curve<T,dim> &crv, size_t n, T dev_max, size_t n_max_pts=5000)
+    auto discretize_with_params(const Curve<T,dim> &crv, size_t n, T dev_max, size_t n_max_pts = approx_max_sample_points)
     {
         auto u_lst = deviation_based_params<T, dim>(crv, n,dev_max,n_max_pts);
         std::vector<T> u{ std::begin(u_lst), std::end(u_lst) };
@@ -655,7 +655,7 @@ namespace gbs
  * @return auto : curve's iterator
  */
     template <typename T, size_t dim>
-    auto closest_curve(const point<T, dim> pt, const auto &curve_begin, const auto &curve_end, T tol = 1e-6)
+    auto closest_curve(const point<T, dim> pt, const auto &curve_begin, const auto &curve_end, T tol = extrema_tol<T>)
     {
         return std::min_element(
             GBS_PAR_EXEC
@@ -677,7 +677,7 @@ namespace gbs
  * @return auto : curve pointer's iterator
  */
     template <typename T, size_t dim>
-    auto closest_p_curve(const point<T, dim> pt, const auto &curve_begin, const auto &curve_end, T tol = 1e-6)
+    auto closest_p_curve(const point<T, dim> pt, const auto &curve_begin, const auto &curve_end, T tol = extrema_tol<T>)
     {
         return std::min_element(
             GBS_PAR_EXEC

--- a/gbs/bscapprox.h
+++ b/gbs/bscapprox.h
@@ -10,11 +10,7 @@
 
 namespace gbs
 {
-    // Below this many parameters a dense normal-equations LDLT beats the sparse
-    // path (SimplicialLDLT setup dominates for small systems); above it the banded
-    // collocation sparsity (p+1 non-zeros per row, sorted params + simple knots)
-    // makes the sparse Cholesky ~O(n*p^2) instead of the dense O(n*n_poles^2) QR.
-    inline constexpr Eigen::Index approx_sparse_threshold = 100;
+    // approx_sparse_threshold is defined in gbs/gbsconstants.h.
 
     // Least-squares pole solve for a banded collocation system through the normal
     // equations C = NᵀN (SPD, banded). This is the book's global LS (A9.6,
@@ -62,10 +58,10 @@ namespace gbs
         }
     }
 
-    // Default starting pole count for the auto-sized curve approximations: twice the
-    // degree. Heuristic shared by every overload that does not take n_poles
-    // explicitly (catalogued for the magic-constants sweep #38).
-    inline size_t default_n_poles(size_t p) { return p * 2; }
+    // Default starting pole count for the auto-sized curve approximations:
+    // default_poles_per_degree * degree. Heuristic shared by every overload that
+    // does not take n_poles explicitly.
+    inline size_t default_n_poles(size_t p) { return p * default_poles_per_degree; }
     /**
      * @brief Approximate a set of points with exact matchin at bounds
      * 
@@ -191,7 +187,7 @@ namespace gbs
     }
 
     template <typename T, size_t dim>
-    auto refine_approx(const points_vector<T, dim> &pts, const std::vector<T> &u,const BSCurve<T, dim> &crv,bool fix_bound, T d_max = 1e-3, T d_avg= 1e-4, size_t n_max = 200)  -> BSCurve<T, dim>
+    auto refine_approx(const points_vector<T, dim> &pts, const std::vector<T> &u,const BSCurve<T, dim> &crv,bool fix_bound, T d_max = approx_dev_max<T>, T d_avg = approx_dev_avg<T>, size_t n_max = approx_max_iter)  -> BSCurve<T, dim>
     {
         auto n_pts = pts.size();
         auto n_poles = crv.poles().size();
@@ -201,7 +197,7 @@ namespace gbs
         // a span, i.e. at least this fraction of the span away from both its knots.
         // This avoids stacking a new knot right on top of an existing one; it is a
         // placement filter only and must NOT influence the stop criterion.
-        constexpr T min_span_fraction = T(0.33);
+        constexpr T min_span_fraction = approx_min_span_fraction<T>;
         for (size_t i {} ; i < n_max; i++)
         {
             // Stop-criterion statistics: the TRUE max/average deviation over ALL
@@ -270,7 +266,7 @@ namespace gbs
         return crv_refined;
     }
     template <typename T, size_t dim>
-    auto approx(const std::vector<std::array<T, dim>> &pts,const std::vector<T> &u, size_t p, bool fix_bound, T d_max = 1e-3, T d_avg= 1e-4, size_t n_max = 200) -> BSCurve<T, dim>
+    auto approx(const std::vector<std::array<T, dim>> &pts,const std::vector<T> &u, size_t p, bool fix_bound, T d_max = approx_dev_max<T>, T d_avg = approx_dev_avg<T>, size_t n_max = approx_max_iter) -> BSCurve<T, dim>
     {
         auto n_poles = default_n_poles(p);
         auto crv = approx(pts, p, n_poles, u, fix_bound);
@@ -289,7 +285,7 @@ namespace gbs
      * @return BSCurve<T, dim> 
      */
     template <typename T, size_t dim>
-    auto approx(const std::vector<std::array<T, dim>> &pts, size_t p, KnotsCalcMode mode, bool fix_bound, T d_max = 1e-3, T d_avg= 1e-4, size_t n_max = 200, bool adimensionnal =false) -> BSCurve<T, dim>
+    auto approx(const std::vector<std::array<T, dim>> &pts, size_t p, KnotsCalcMode mode, bool fix_bound, T d_max = approx_dev_max<T>, T d_avg = approx_dev_avg<T>, size_t n_max = approx_max_iter, bool adimensionnal =false) -> BSCurve<T, dim>
     {
         auto u = curve_parametrization(pts, mode, adimensionnal);
         return approx(pts,u,p,fix_bound,d_max,d_avg,n_max);
@@ -349,7 +345,7 @@ namespace gbs
      * @return BSCurve<T, dim> 
      */
     template <typename T, size_t dim>
-    auto approx(const Curve<T,dim> &crv, T deviation, size_t p, KnotsCalcMode mode, size_t np = 30) -> BSCurve<T, dim>
+    auto approx(const Curve<T,dim> &crv, T deviation, size_t p, KnotsCalcMode mode, size_t np = approx_sample_count) -> BSCurve<T, dim>
     {
         auto pts = discretize(crv,np,deviation);
         return approx(pts,p,mode,true);
@@ -394,7 +390,7 @@ namespace gbs
      * @return auto 
      */
     template <typename T, size_t dim>
-    auto approx(const Curve<T, dim> &crv, size_t p, size_t n_poles, std::vector<T> k_flat, T deviation, size_t np, size_t n_max_pts=5000)
+    auto approx(const Curve<T, dim> &crv, size_t p, size_t n_poles, std::vector<T> k_flat, T deviation, size_t np, size_t n_max_pts = approx_max_sample_points)
     {
         auto u_lst = deviation_based_params<T, dim>(crv, np,deviation,n_max_pts);
         std::vector<T> u{std::begin(u_lst), std::end(u_lst)};
@@ -414,7 +410,7 @@ namespace gbs
      * @return BSCurve<T, dim> 
      */
     template <typename T, size_t dim>
-    auto approx(const Curve<T,dim> &crv, T deviation,T tol, size_t p, size_t np = 30) -> BSCurve<T, dim>
+    auto approx(const Curve<T,dim> &crv, T deviation,T tol, size_t p, size_t np = approx_sample_count) -> BSCurve<T, dim>
     {
         auto [pts, u] = sample_by_deviation(crv, np, deviation);
         return refine_from_points(pts, u, p, std::max<size_t>(np / 3, p + 1), tol);
@@ -452,7 +448,7 @@ namespace gbs
      * @return BSCurve<T, dim> 
      */
     template <typename T, size_t dim>
-    auto approx(const Curve<T,dim> &crv, T u1, T u2, T deviation,T tol, size_t p, size_t np = 30) -> BSCurve<T, dim>
+    auto approx(const Curve<T,dim> &crv, T u1, T u2, T deviation,T tol, size_t p, size_t np = approx_sample_count) -> BSCurve<T, dim>
     {
         // NB: u1/u2 are currently not applied (the whole curve is sampled), matching
         // the pre-existing behaviour; left as-is to keep this a pure refactor.
@@ -467,7 +463,7 @@ namespace gbs
         T deviation,
         T tol, 
         size_t p, 
-        size_t np = 30
+        size_t np = approx_sample_count
         ) -> BSCurve<T, dim>
     {
         auto [pts, u] = sample_by_deviation(crv, np, deviation);

--- a/gbs/bscinterp.h
+++ b/gbs/bscinterp.h
@@ -28,13 +28,7 @@ struct constrPoint
     size_t d;
 };
 
-// Below this number of unknowns a dense LU beats a sparse one: SparseLU's
-// symbolic analysis + fill-reducing ordering have a fixed overhead that dominates
-// for small systems. Above it, the banded collocation sparsity (only p+1 non-zero
-// entries per row, from the one-pass assembly) makes the sparse solve much
-// cheaper than the dense O(n^3) factorization. Keeps small interpolations on the
-// dense path so they are never penalized.
-inline constexpr Eigen::Index interp_sparse_threshold = 100;
+// interp_sparse_threshold is defined in gbs/gbsconstants.h.
 
 /**
  * @brief Solve the collocation system N * X = B for all dim right-hand sides,

--- a/gbs/bsctools.h
+++ b/gbs/bsctools.h
@@ -52,7 +52,7 @@ namespace gbs
      * @return A shared pointer to the resulting BSCurve.
      */
     template <typename T, size_t dim>
-    auto to_bs_curve(const std::shared_ptr < Curve<T, dim> > &crv, T dev = 0.01, size_t np = 100, size_t deg_approx = 5, KnotsCalcMode mode = KnotsCalcMode::CHORD_LENGTH) -> std::shared_ptr < BSCurve<T, dim> >
+    auto to_bs_curve(const std::shared_ptr < Curve<T, dim> > &crv, T dev = bs_conversion_dev<T>, size_t np = bs_conversion_np, size_t deg_approx = bs_conversion_degree, KnotsCalcMode mode = KnotsCalcMode::CHORD_LENGTH) -> std::shared_ptr < BSCurve<T, dim> >
     {
         auto p_bs = std::dynamic_pointer_cast<const BSCurve<T, dim> >(crv);
         if (p_bs)

--- a/gbs/bssanalysis.h
+++ b/gbs/bssanalysis.h
@@ -80,7 +80,7 @@ namespace gbs
  * @return A list of curve parameters with the refined deviation
  */
     template <typename T, size_t dim>
-    auto deviation_based_u_params(const Surface<T, dim> &srf, T u1, T u2, T v,size_t n, T dev_max, size_t n_max_pts = 5000) -> std::list<T>
+    auto deviation_based_u_params(const Surface<T, dim> &srf, T u1, T u2, T v,size_t n, T dev_max, size_t n_max_pts = approx_max_sample_points) -> std::list<T>
     {
         // Create initial list of parameters
         std::list<T> u_lst;
@@ -147,7 +147,7 @@ namespace gbs
  * @return A list of curve parameters with the refined deviation
  */
     template <typename T, size_t dim>
-    auto deviation_based_v_params(const Surface<T, dim> &srf, T v1, T v2, T u,size_t n, T dev_max, size_t n_max_pts = 5000) -> std::list<T>
+    auto deviation_based_v_params(const Surface<T, dim> &srf, T v1, T v2, T u,size_t n, T dev_max, size_t n_max_pts = approx_max_sample_points) -> std::list<T>
     {
         // Create initial list of parameters
         std::list<T> v_lst;

--- a/gbs/bssbuild.h
+++ b/gbs/bssbuild.h
@@ -153,7 +153,7 @@ namespace gbs
                 v_spine.begin(),
                 [&spine](const Curve<T, dim> &profile_)
                 {
-                    return extrema_curve_curve<T,dim>(spine,profile_,1e-6)[0];
+                    return extrema_curve_curve<T,dim>(spine,profile_,extrema_tol<T>)[0];
                 }
         );
         // compute spine distances (model space — the spine is non-rational)
@@ -344,7 +344,7 @@ namespace gbs
         std::transform(
             bs_lst_cpy.begin(), bs_lst_cpy.end(), v.begin(),
             [&spine](const Curve<T, dim> &profile_) {
-                return extrema_curve_curve<T, dim>(spine, profile_, 1e-6)[0];
+                return extrema_curve_curve<T, dim>(spine, profile_, extrema_tol<T>)[0];
             });
         // The spine's absolute parameter values are not meaningful as surface
         // coordinates — only their ordering/relative spacing is. Normalize the
@@ -480,7 +480,7 @@ namespace gbs
      * @throws std::invalid_argument if any curve in the range does not touch 'crv' within the specified tolerance.
      */
     template <typename T, size_t dim, typename InputIt>
-    auto build_intersections(InputIt first_curve, InputIt last_curve, const Curve<T, dim> &crv, T tol = 1e-6) -> std::vector<T>
+    auto build_intersections(InputIt first_curve, InputIt last_curve, const Curve<T, dim> &crv, T tol = extrema_tol<T>) -> std::vector<T>
     {
         auto nu = std::distance(first_curve, last_curve);
         std::vector<T> u(nu);
@@ -525,7 +525,7 @@ namespace gbs
      * @throws std::invalid_argument if any pair of curves from the two sets do not intersect within the specified tolerance.
      */
     template <typename T, size_t dim, typename InputIt>
-    auto build_intersections(InputIt first_u, InputIt last_u, InputIt first_v, InputIt last_v, T tol = 1e-6)
+    auto build_intersections(InputIt first_u, InputIt last_u, InputIt first_v, InputIt last_v, T tol = extrema_tol<T>)
     {
         auto nu = std::distance(first_u, last_u);
         auto nv = std::distance(first_v, last_v);
@@ -559,7 +559,7 @@ namespace gbs
     }
 
     template <typename T, size_t dim, typename ForwardIt>
-    auto gordon(ForwardIt first_u,ForwardIt last_u,ForwardIt first_v,ForwardIt last_v, T tol = 1e-6) -> BSSurface<T,dim>
+    auto gordon(ForwardIt first_u,ForwardIt last_u,ForwardIt first_v,ForwardIt last_v, T tol = extrema_tol<T>) -> BSSurface<T,dim>
     {
 
         // gather informations

--- a/gbs/gbsconstants.h
+++ b/gbs/gbsconstants.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+// =============================================================================
+// gbs tuning constants — single source of truth
+// -----------------------------------------------------------------------------
+// Hard-coded numeric constants that tune the core algorithms (tolerances,
+// solver thresholds and default algorithm parameters) live here instead of
+// being re-typed at every call site. Each one is named and documented so the
+// intent is explicit and the value can be reviewed / tuned in one place.
+//
+// Tolerances and floating defaults are templated on the scalar type so they
+// adapt to `float` / `double`; integer thresholds are plain `inline constexpr`.
+//
+// NOTE: algorithm-intrinsic constants (e.g. the Shewchuk robust-predicate error
+// bounds in inc/topology/robustPredicates.h, or the Gauss-Kronrod point count)
+// are NOT tuning knobs and deliberately stay with their algorithm.
+// =============================================================================
+
+namespace gbs
+{
+    // ---- Knot / parameter comparison tolerance -----------------------------
+    // Two knots (or curve parameters) closer than this are treated as equal.
+    // Scaled off the machine epsilon so it tracks the working precision.
+    template <typename T>
+    inline constexpr T knot_eps = std::numeric_limits<T>::epsilon() * 100;
+
+    // ---- Allocation-free evaluator capacity --------------------------------
+    // Largest B-spline degree the allocation-free evaluators handle on the
+    // stack. Real CAD/CAM degrees are well under this; beyond it the evaluators
+    // fall back to the (correct but slow) recursive basis_function so behaviour
+    // never silently breaks. Stack cost is O((max+1)^2) scalars.
+    inline constexpr std::size_t bspline_stack_max_degree = 24;
+
+    // ---- Dense vs sparse linear-solve cutoffs ------------------------------
+    // Below this number of unknowns a dense LU/LDLT beats the sparse path: the
+    // sparse setup (symbolic analysis / fill-reducing ordering) has a fixed
+    // overhead that dominates for small systems, while above it the banded
+    // collocation sparsity (p+1 non-zeros per row) makes the sparse solve much
+    // cheaper than the dense O(n^3) factorization.
+    inline constexpr std::ptrdiff_t interp_sparse_threshold = 100; // interpolation (LU)
+    inline constexpr std::ptrdiff_t approx_sparse_threshold = 100; // approximation (Cholesky)
+
+    // ---- Curve/surface intersection & extrema tolerance --------------------
+    // Default tolerance for extrema / intersection / projection searches
+    // (extrema_curve_curve, build_intersections, gordon, closest_curve, ...).
+    template <typename T>
+    inline constexpr T extrema_tol = T(1e-6);
+
+    // ---- Delaunay / Boyer-Watson mesh tolerance ----------------------------
+    // Default tolerance for the in-circle / orientation predicates and the
+    // mesh-editing geometry tests (Boyer-Watson, edge recovery, point-in-face).
+    template <typename T>
+    inline constexpr T delaunay_tol = T(1e-10);
+
+    // ---- Least-squares approximation defaults ------------------------------
+    // Max / mean deviation targets of the iterative refinement (refine_approx,
+    // approx).
+    template <typename T>
+    inline constexpr T approx_dev_max = T(1e-3);
+    template <typename T>
+    inline constexpr T approx_dev_avg = T(1e-4);
+    // Cap on the refinement iterations (knot-insertion passes).
+    inline constexpr std::size_t approx_max_iter = 200;
+    // A refinement knot is only inserted when both surrounding spans keep at
+    // least this fraction of their length, so knots never pile up at a boundary.
+    template <typename T>
+    inline constexpr T approx_min_span_fraction = T(0.33);
+    // Default number of points for a preliminary curve discretization.
+    inline constexpr std::size_t approx_sample_count = 30;
+    // Hard cap on the points produced by deviation-based discretization.
+    inline constexpr std::size_t approx_max_sample_points = 5000;
+    // default_n_poles heuristic: poles ~= this factor * degree.
+    inline constexpr std::size_t default_poles_per_degree = 2;
+
+    // ---- Curve -> B-spline conversion / loft defaults ----------------------
+    // Defaults shared by to_bs_curve() and loft() when approximating an
+    // arbitrary Curve by a BSCurve.
+    template <typename T>
+    inline constexpr T bs_conversion_dev = T(0.01); // max deviation target
+    inline constexpr std::size_t bs_conversion_np = 100;     // discretization points
+    inline constexpr std::size_t bs_conversion_degree = 5;   // approximation degree
+    inline constexpr std::size_t loft_v_degree_max = 3;      // default max v-degree of a loft
+} // namespace gbs

--- a/gbs/gbslib.h
+++ b/gbs/gbslib.h
@@ -19,10 +19,10 @@
 #include <vector>
 #include <array>
 #include <tuple>
+#include <gbs/gbsconstants.h>
 namespace gbs
 {
-template< typename T>
-constexpr double knot_eps = std::numeric_limits<T>::epsilon() * 100;
+// knot_eps and the other tuning constants now live in gbs/gbsconstants.h.
 
 template <typename T,size_t dim>
      using point = std::array<T,dim>;

--- a/gbs/loft/loftCurves.h
+++ b/gbs/loft/loftCurves.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "loftGeneric.h"
+#include <gbs/gbsconstants.h>
 #include <ranges>
 #include <initializer_list>
 
@@ -110,7 +111,7 @@ namespace gbs{
      * @return A lofted surface created from the input curves.
      */
     template <typename T, size_t dim>
-    auto loft(const std::vector<std::shared_ptr<Curve<T, dim>>> &crv_lst, size_t v_degree_max = 3,T dev = 0.01, size_t np=100, size_t deg_approx=5)
+    auto loft(const std::vector<std::shared_ptr<Curve<T, dim>>> &crv_lst, size_t v_degree_max = loft_v_degree_max,T dev = bs_conversion_dev<T>, size_t np = bs_conversion_np, size_t deg_approx = bs_conversion_degree)
     {
         std::vector<std::shared_ptr < BSCurve<T, dim> >> bs_lst(crv_lst.size());
         std::transform(
@@ -140,7 +141,7 @@ namespace gbs{
      * @return A lofted surface created from the input curves with specified knot vector and degree.
      */
     template <typename T, size_t dim>
-    auto loft(const std::vector<std::shared_ptr<Curve<T, dim>>> &crv_lst, const std::vector<T> &v, size_t q,T dev = 0.01, size_t np=100, size_t deg_approx=5)
+    auto loft(const std::vector<std::shared_ptr<Curve<T, dim>>> &crv_lst, const std::vector<T> &v, size_t q,T dev = bs_conversion_dev<T>, size_t np = bs_conversion_np, size_t deg_approx = bs_conversion_degree)
     {
         std::vector<std::shared_ptr < BSCurve<T, dim> >> bs_lst(crv_lst.size());
         std::transform(

--- a/inc/topology/tessellations.h
+++ b/inc/topology/tessellations.h
@@ -125,7 +125,7 @@ namespace bw_detail
  * @return A tuple ( new vertex, deleted HalfEdgeFaces that were violating the Delaunay condition, the newly created HalfEdgeFaces).
  */
     template<std::floating_point T, typename Container>
-    auto boyerWatson(Container& h_f_lst, const std::array<T, 2>& xy, T tol = T{1e-10}) {
+    auto boyerWatson(Container& h_f_lst, const std::array<T, 2>& xy, T tol = delaunay_tol<T>) {
         using std::begin;
         using std::end;
         using Face = std::shared_ptr<HalfEdgeFace<T, 2>>;
@@ -303,7 +303,7 @@ namespace bw_detail
  * @return A container of triangulated faces forming the Delaunay triangulation.
  */
     template < std::floating_point T>
-    auto delaunay2DBoyerWatson(const std::vector< std::array<T,2> > &coords, T tol = 1e-10)
+    auto delaunay2DBoyerWatson(const std::vector< std::array<T,2> > &coords, T tol = delaunay_tol<T>)
     {
         return delaunay2DBoyerWatson<T,std::vector< std::array<T,2> >>(coords, tol);
     }
@@ -331,7 +331,7 @@ namespace bw_detail
     auto delaunay2DConstrained(
         const std::vector<std::array<T, 2>> &outer,
         const std::vector<std::vector<std::array<T, 2>>> &holes,
-        T tol = T{1e-10})
+        T tol = delaunay_tol<T>)
     {
         // Each polygon ring is described by a vector of vertices in domain-CCW
         // order: the outer polygon walks CCW around the domain; each hole, as
@@ -439,7 +439,7 @@ namespace bw_detail
 
     /// Convenience overload: simple polygon, no holes.
     template <std::floating_point T>
-    auto delaunay2DConstrained(const std::vector<std::array<T, 2>> &outer, T tol = T{1e-10})
+    auto delaunay2DConstrained(const std::vector<std::array<T, 2>> &outer, T tol = delaunay_tol<T>)
     {
         return delaunay2DConstrained<T>(outer, std::vector<std::vector<std::array<T, 2>>>{}, tol);
     }
@@ -457,7 +457,7 @@ namespace bw_detail
  * @return A container of triangulated faces forming the refined Delaunay triangulation of the surface mesh.
  */
     template <std::floating_point T, size_t dim, typename _Func>
-    auto delaunay2DBoyerWatsonSurfaceMeshRefine(const Surface<T, dim> &srf, auto &faces_lst, T crit_max, size_t max_inner_points = 500, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonSurfaceMeshRefine(const Surface<T, dim> &srf, auto &faces_lst, T crit_max, size_t max_inner_points = 500, T tol = delaunay_tol<T>)
     {
         _Func dist_mesh_srf{srf};
 
@@ -507,7 +507,7 @@ namespace bw_detail
 
 
     template <std::floating_point T, size_t dim, typename _Func>
-    auto delaunay2DBoyerWatsonMeshRefine(auto &faces_lst, T crit_max, const _Func &dist_mesh, size_t max_inner_points = 500, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonMeshRefine(auto &faces_lst, T crit_max, const _Func &dist_mesh, size_t max_inner_points = 500, T tol = delaunay_tol<T>)
     {
         // Store face quality in a map
         std::unordered_map<std::shared_ptr<HalfEdgeFace<T, dim>>, T> face_quality;
@@ -568,7 +568,7 @@ namespace bw_detail
     }
 
     template <std::floating_point T, size_t dim, typename _Func>
-    auto delaunay2DBoyerWatsonMeshRefine(auto &faces_lst, T crit_max, size_t max_inner_points = 500, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonMeshRefine(auto &faces_lst, T crit_max, size_t max_inner_points = 500, T tol = delaunay_tol<T>)
     {
         _Func dist_mesh{};
         return delaunay2DBoyerWatsonMeshRefine<T,dim,_Func>(faces_lst, crit_max, dist_mesh, max_inner_points, tol);
@@ -587,7 +587,7 @@ namespace bw_detail
  * @return A container of triangulated faces forming the base Delaunay triangulation of the surface.
  */
     template < std::floating_point T, size_t dim>
-    auto delaunay2DBoyerWatsonSurfaceBase(const Surface<T,dim> &srf, size_t nu = 5, size_t nv = 5, T deviation = 0.01, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonSurfaceBase(const Surface<T,dim> &srf, size_t nu = 5, size_t nv = 5, T deviation = 0.01, T tol = delaunay_tol<T>)
     {
     
         auto coords = meshSurfaceBoundary(srf, nu ,nv, deviation);
@@ -622,7 +622,7 @@ namespace bw_detail
  * @return A container of triangulated faces forming the refined Delaunay triangulation of the surface mesh.
  */
     template < std::floating_point T, size_t dim, typename _Func >
-    auto delaunay2DBoyerWatsonSurfaceMesh(const Surface<T,dim> &srf, T crit_max, size_t max_inner_points = 500, size_t nu = 5, size_t nv = 5, T deviation = 0.01, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonSurfaceMesh(const Surface<T,dim> &srf, T crit_max, size_t max_inner_points = 500, size_t nu = 5, size_t nv = 5, T deviation = 0.01, T tol = delaunay_tol<T>)
     {
         auto faces_lst = delaunay2DBoyerWatsonSurfaceBase(srf, nu, nv, deviation, tol);
         return delaunay2DBoyerWatsonSurfaceMeshRefine<T, dim, _Func>(srf, faces_lst, crit_max, max_inner_points, tol); 
@@ -638,7 +638,7 @@ namespace bw_detail
  * @return A container of triangulated faces forming the Delaunay triangulation with the added inner boundary.
  */
     template < std::floating_point T, size_t dim>
-    auto delaunay2DBoyerWatsonAddInnerBound(auto &faces_lst, const std::vector<std::array<T,dim>> &coords_inner, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonAddInnerBound(auto &faces_lst, const std::vector<std::array<T,dim>> &coords_inner, T tol = delaunay_tol<T>)
     {
         for (const auto &xy : coords_inner)
         {
@@ -658,7 +658,7 @@ namespace bw_detail
  * @return A container of triangulated faces forming the Delaunay triangulation with the added outer boundary.
  */
     template <std::floating_point T, size_t dim>
-    auto delaunay2DBoyerWatsonAddOuterBound(auto &faces_lst, const std::vector<std::array<T,dim>> &coords_outer, T tol = 1e-10)
+    auto delaunay2DBoyerWatsonAddOuterBound(auto &faces_lst, const std::vector<std::array<T,dim>> &coords_outer, T tol = delaunay_tol<T>)
     {
         for (const auto &xy : coords_outer)
         {


### PR DESCRIPTION
## Summary
Eliminates scattered **magic numbers** in the core library by collecting the tuning constants (tolerances, solver thresholds, default algorithm parameters) into a single documented header, **`gbs/gbsconstants.h`**. Constants live in `namespace gbs` (so existing unqualified uses keep working), are grouped by domain, and are templated on the scalar type where they are tolerances. **Values are unchanged — pure refactor, no behavioural change.**

This is the last open child of epic #44.

## What moved / got named
**Relocated** (definition → the header, every use unchanged):
- `knot_eps` (from `gbslib.h`)
- `bspline_stack_max_degree` (from `basisfunctions.ixx`)
- `interp_sparse_threshold` (from `bscinterp.h`)
- `approx_sparse_threshold` (from `bscapprox.h`)

**Named and replaced at call sites:**
- `extrema_tol` (`1e-6`) — extrema / intersection / projection defaults (`bscanalysis.h`, `bssbuild.h`)
- `delaunay_tol` (`1e-10`) — Boyer-Watson / Delaunay tolerance defaults (`tessellations.h`)
- `approx_dev_max`/`approx_dev_avg` (`1e-3`/`1e-4`), `approx_max_iter` (`200`), `approx_min_span_fraction` (`0.33`), `approx_sample_count` (`30`), `approx_max_sample_points` (`5000`), `default_poles_per_degree` (`2`) (`bscapprox.h`, `bscanalysis.h`, `bssanalysis.h`)
- `bs_conversion_dev`/`np`/`degree` (`0.01`/`100`/`5`) and `loft_v_degree_max` (`3`), shared by `to_bs_curve` (`bsctools.h`) and `loft` (`loft/loftCurves.h`)

## Scope boundaries
Deliberately **left with their algorithm** (these are not tunable knobs):
- the Shewchuk robust-predicate error bounds in `robustPredicates.h`
- the Gauss-Kronrod point count `N_gauss_pt`

The deeper mesh-editor predicate tolerances in the other `inc/topology/` files (`baseIntersection.h`, `edgeRecovery.h`, `halfEdgeMesh*`) are a separate layer from the Boyer-Watson entry points the epic names; left out of this pass.

## Verification
16 affected C++ test suites built and run locally (clang / OCCT 7.8):

```
tests_knotsfunctions, tests_checkcurves, tests_basisfunctions, tests_bscurve,
tests_bsinterp, tests_bscapprox, tests_approx, tests_extrema, tests_bscanalysis,
tests_bssanalysis, tests_bssbuild, tests_bsctools, tests_bscbuild, tests_mesh,
tests_halfedgemesh, tests_surfaces
```
→ **all SUCCESS, 0 failed (~33,500 assertions).** CI runs the full matrix.

Closes #38. Refs epic #44.