### PR TITLE
perf(#88): size-gated parallel bulk evaluators (values / d_dms / d_dmus …)

### DIFF
--- a/bench/PARALLEL_AUDIT.md
+++ b/bench/PARALLEL_AUDIT.md
@@ -340,6 +340,46 @@ helper that #89 and #91 reuse.
    loop) — each build is independent, measured **8–28×** (K=100–1000). *Not*
    intra-build: a single solve has no useful parallel axis.
 
+## #88 — post-implementation validation (gated library path)
+
+#88 (PR #93) landed the shared `gbs::transform_threshold` helper (gate
+`gbs::parallel_min_size = 1000`, `gbs/gbsconstants.h`) and routed every bulk
+evaluator through it (curve `values`/`d_dms`/`d_dm2s`, surface `values` ×2 /
+`d_dmus`/`d_dmvs`/`d_dmu2s`/`d_dmv2s`). This section archives a **fresh
+`bench_parallel` run on the post-#88 tree** (gcc-15 `-O3` Release, libstdc++ +
+TBB; 64-hw-thread machine; best-of-N wall time) — both to re-confirm the audit's
+seq-vs-par numbers still hold and to validate the **shipped, gated** code path.
+
+**Re-confirmation — sections [1]–[4] track the original audit within noise** (same
+machine), e.g. curve `value` 7.6× at N=100k / 9.1× at N=1M, surface `value` 13.6× at
+N=100k, offset point 16–18× at N≥100k, all `bit-identical`. The crossover sweeps
+[6a]/[6b] reproduce too: the light curve-value kernel flips to `par` at **N=1000**
+(0.70× at 500 → 1.12× at 1000), the heavy offset kernel near **N=50–100** — which is
+exactly why the conservative default gate is **1000** and heavy workloads may lower it.
+
+**New — [8] drives the actual shipped `crv.values()` (gated), not a kernel replica.**
+It is timed per call against an explicit-serial reference, across N straddling the
+gate. Below the gate the library call takes the **serial** branch (≈ seq cost — *no*
+regression, vs the 0.04–0.26× an *un*gated `par` inflicts at the same sizes per [6a]);
+at/above 1000 it takes `par` and wins; every row is bit-identical to serial:
+
+| N | seq µs/call | gated µs/call | gated/seq | policy / result |
+|---|-------------|---------------|-----------|-----------------|
+| 100   | 3.78   | 4.38   | 0.86× | seq / identical |
+| 500   | 19.10  | 22.05  | 0.87× | seq / identical |
+| 999   | 37.61  | 43.52  | 0.86× | seq / identical |
+| 1000  | 37.55  | 35.54  | 1.06× | par / identical |
+| 2000  | 74.82  | 48.23  | 1.55× | par / identical |
+| 10000 | 369.9  | 113.7  | 3.25× | par / identical |
+
+Reading: the ~0.86× below the gate is the generic-evaluator overhead (virtual
+`value()` + the `std::distance` check), **not** a parallel regression — the gate has
+correctly kept those calls serial. The win switches on exactly at
+`parallel_min_size`, confirming the measured threshold is placed at the break-even.
+
+The `[8]` section was added to `bench/bench_parallel.cpp` for this validation; run it
+with the same command below.
+
 ## Reproduce
 ```
 scripts/build_bench.sh bench_parallel

--- a/bench/bench_parallel.cpp
+++ b/bench/bench_parallel.cpp
@@ -384,6 +384,36 @@ int main()
         }
     }
 
+    // ---- 8. gated library path (#88) --------------------------------------
+    // Sections [1]-[7] time policy-applied kernel replicas. This one drives the
+    // *shipped* evaluator crv.values(), which now routes through
+    // gbs::transform_threshold (seuil gbs::parallel_min_size). It confirms the
+    // production call picks the serial branch below the gate (so small calls are
+    // NOT regressed vs explicit seq) and the parallel win above it, while staying
+    // bit-identical to the explicit-serial reference.
+    {
+        std::printf("\n[8] GATED LIBRARY PATH  (#88: crv.values() via transform_threshold, seuil = %zu)\n",
+                    gbs::parallel_min_size);
+        std::printf("%-8s %14s %14s %12s %s\n", "N", "seq us/call", "gated us/call", "gated/seq", "policy/result");
+        std::printf("----------------------------------------------------------------------\n");
+        for (size_t N : {size_t{100}, size_t{500}, size_t{999}, size_t{1000}, size_t{2000}, size_t{10000}})
+        {
+            auto u = param_list(bc, N);
+            size_t M = std::max<size_t>(1, 4000000 / N);
+            points_vector<double, 3> ref;
+            double sus = best_ms(5, [&] {
+                for (size_t m = 0; m < M; ++m) { ref = eval_curve(std::execution::seq, crv, u); sink += ref[0][0]; }
+            }) * 1000.0 / double(M);
+            points_vector<double, 3> got;
+            double gus = best_ms(5, [&] {
+                for (size_t m = 0; m < M; ++m) { got = crv.values(u); sink += got[0][0]; }
+            }) * 1000.0 / double(M);
+            const char *pol = (N >= gbs::parallel_min_size) ? "par" : "seq";
+            std::printf("%-8zu %14.3f %14.3f %11.2fx  %s/%s\n", N, sus, gus, sus / gus,
+                        pol, bit_identical(ref, got) ? "identical" : "DIFFERS");
+        }
+    }
+
     std::printf("\n[sink=%g]\n", sink);
     return 0;
 }

--- a/gbs/bscurve.h
+++ b/gbs/bscurve.h
@@ -13,6 +13,7 @@
 #endif
 #include "exceptions.h"
 #include "gbslib.h"
+#include "execution.h"
 
 #include <algorithm>
 #include <vector>
@@ -64,8 +65,7 @@ namespace gbs
         auto values(const _Container<T, Args...> &u_lst, size_t d = 0) const -> points_vector<T, dim>
         {
             points_vector<T, dim> values(u_lst.size());
-            // Parallelization doesn't seems to be worth
-            std::transform(
+            transform_threshold(
                 u_lst.begin(), u_lst.end(),
                 values.begin(),
                 [this, d](auto u){return this->value(u, d);}
@@ -159,7 +159,7 @@ namespace gbs
         auto d_dms(const _Container<T, Args...> &u_lst) const -> points_vector<T, dim>
         {
             points_vector<T, dim> res(u_lst.size());
-            std::transform(
+            transform_threshold(
                 u_lst.begin(), u_lst.end(),
                 res.begin(),
                 [this](auto u){return this->d_dm(u);}
@@ -178,7 +178,7 @@ namespace gbs
         auto d_dm2s(const _Container<T, Args...> &u_lst) const -> points_vector<T, dim>
         {
             points_vector<T, dim> res(u_lst.size());
-            std::transform(
+            transform_threshold(
                 u_lst.begin(), u_lst.end(),
                 res.begin(),
                 [this](auto u){return this->d_dm2(u);}

--- a/gbs/bssurf.h
+++ b/gbs/bssurf.h
@@ -136,8 +136,7 @@ namespace gbs
         auto values(const _Container<std::array<T, 2>, Args...> &uv_lst, size_t du = 0, size_t dv = 0) const -> points_vector<T, dim>
         {
             std::vector<std::array<T, dim>> values(uv_lst.size());
-            // Parallelization doesn't seems to be worth
-            std::transform(
+            transform_threshold(
                 uv_lst.begin(), uv_lst.end(),
                 values.begin(),
                 [this, du, dv](const auto &uv){return this->value(uv, du, dv);}
@@ -168,8 +167,7 @@ namespace gbs
         {
             assert( u_lst.size() == v_lst.size() );
             std::vector<std::array<T, dim>> values(u_lst.size());
-            // Parallelization doesn't seems to be worth
-            std::transform(
+            transform_threshold(
                 u_lst.begin(), u_lst.end(),
                 v_lst.begin(),
                 values.begin(),
@@ -316,7 +314,7 @@ namespace gbs
         auto d_dmus(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
         {
             points_vector<T, dim> res(uv_lst.size());
-            std::transform(
+            transform_threshold(
                 uv_lst.begin(), uv_lst.end(),
                 res.begin(),
                 [this](const auto &uv){return this->d_dmu(uv[0], uv[1]);}
@@ -336,7 +334,7 @@ namespace gbs
         auto d_dmvs(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
         {
             points_vector<T, dim> res(uv_lst.size());
-            std::transform(
+            transform_threshold(
                 uv_lst.begin(), uv_lst.end(),
                 res.begin(),
                 [this](const auto &uv){return this->d_dmv(uv[0], uv[1]);}
@@ -356,7 +354,7 @@ namespace gbs
         auto d_dmu2s(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
         {
             points_vector<T, dim> res(uv_lst.size());
-            std::transform(
+            transform_threshold(
                 uv_lst.begin(), uv_lst.end(),
                 res.begin(),
                 [this](const auto &uv){return this->d_dmu2(uv[0], uv[1]);}
@@ -376,7 +374,7 @@ namespace gbs
         auto d_dmv2s(const _Container<std::array<T, 2>, Args...> &uv_lst) const -> points_vector<T, dim>
         {
             points_vector<T, dim> res(uv_lst.size());
-            std::transform(
+            transform_threshold(
                 uv_lst.begin(), uv_lst.end(),
                 res.begin(),
                 [this](const auto &uv){return this->d_dmv2(uv[0], uv[1]);}

--- a/gbs/execution.h
+++ b/gbs/execution.h
@@ -4,6 +4,11 @@
 // Fall back to sequential algorithms on that platform.
 #include <version>
 #include <numeric>  // std::reduce, std::transform_reduce (previously transitive via <execution>)
+#include <algorithm>  // std::transform
+#include <iterator>   // std::distance
+#include <cstddef>    // std::size_t
+
+#include "gbsconstants.h"  // gbs::parallel_min_size
 
 #if defined(__cpp_lib_execution)
     #include <execution>
@@ -35,5 +40,43 @@ namespace gbs
     inline constexpr parallel_execution_policy  par_exec{};
     inline constexpr sequenced_execution_policy seq_exec{};
 #endif
+
+    // -------------------------------------------------------------------------
+    // Size-gated parallel transform — the shared helper for bulk evaluators.
+    // -------------------------------------------------------------------------
+    // Dispatches std::transform to the parallel execution policy (GBS_PAR_EXEC)
+    // only when the input range has at least `gbs::parallel_min_size` elements,
+    // and runs serially below that. The parallel STL (libstdc++/MSVC) does not
+    // cheaply fall back to serial for small ranges: it still spins up the TBB
+    // task machinery (~9-15 us fixed cost), so an *unconditional* `par` regresses
+    // small calls by up to 25x. The gate avoids that regression while keeping the
+    // 2-21x win on large inputs. See bench/PARALLEL_AUDIT.md (#84/#92).
+    //
+    // Determinism: each iteration writes a distinct, pre-indexed output slot and
+    // there is no reduction, so the result is BIT-IDENTICAL regardless of the
+    // policy chosen or the thread count. The gate only selects the policy by
+    // size; it never changes the result.
+    //
+    // Portability: on platforms without parallel policies (Apple libc++)
+    // GBS_PAR_EXEC is empty, so both branches are serial and the gate is a
+    // correctness-preserving no-op.
+
+    /// Size-gated unary std::transform (single input range).
+    template <class InputIt, class OutputIt, class UnaryOp>
+    OutputIt transform_threshold(InputIt first, InputIt last, OutputIt out, UnaryOp op)
+    {
+        if (static_cast<std::size_t>(std::distance(first, last)) >= parallel_min_size)
+            return std::transform(GBS_PAR_EXEC first, last, out, op);
+        return std::transform(first, last, out, op);
+    }
+
+    /// Size-gated binary std::transform (two input ranges).
+    template <class InputIt1, class InputIt2, class OutputIt, class BinaryOp>
+    OutputIt transform_threshold(InputIt1 first1, InputIt1 last1, InputIt2 first2, OutputIt out, BinaryOp op)
+    {
+        if (static_cast<std::size_t>(std::distance(first1, last1)) >= parallel_min_size)
+            return std::transform(GBS_PAR_EXEC first1, last1, first2, out, op);
+        return std::transform(first1, last1, first2, out, op);
+    }
 }
 

--- a/gbs/gbsconstants.h
+++ b/gbs/gbsconstants.h
@@ -43,6 +43,20 @@ namespace gbs
     inline constexpr std::ptrdiff_t interp_sparse_threshold = 100; // interpolation (LU)
     inline constexpr std::ptrdiff_t approx_sparse_threshold = 100; // approximation (Cholesky)
 
+    // ---- Parallel-execution size gate --------------------------------------
+    // Bulk evaluators (values / d_dms / d_dmus ...) route std::transform through
+    // gbs::transform_threshold (gbs/execution.h), which dispatches to the
+    // parallel execution policy only when the input has at least this many
+    // elements and runs serially below it. The parallel STL (libstdc++/MSVC)
+    // does not cheaply fall back to serial for small ranges: it still spins up
+    // the TBB task machinery (~9-15 us fixed cost, measured), so an unconditional
+    // `par` regresses small calls by up to 25x. 1000 is the conservative,
+    // *measured* break-even for the lightest kernel (curve value); heavier
+    // kernels (offset, d_dm2) cross over near ~64-128, so a known-heavy workload
+    // may lower this. See bench/PARALLEL_AUDIT.md (#84/#92). Mutable so it can be
+    // tuned at runtime per workload.
+    inline std::size_t parallel_min_size = 1000;
+
     // ---- Curve/surface intersection & extrema tolerance --------------------
     // Default tolerance for extrema / intersection / projection searches
     // (extrema_curve_curve, build_intersections, gordon, closest_curve, ...).

--- a/tests/tests_parallel_eval.cpp
+++ b/tests/tests_parallel_eval.cpp
@@ -1,0 +1,262 @@
+#include <doctest_gtest.hpp>
+#include <gbs/bscurve.h>
+#include <gbs/bssurf.h>
+#include <gbs/execution.h>
+
+#include <array>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+// Coverage for #88: bulk evaluators route std::transform through the size-gated
+// gbs::transform_threshold helper. The gate only chooses the execution policy by
+// input size; it must NEVER change the result. Every check below compares the
+// bulk path to a per-element serial reference with EXACT equality (operator==,
+// no tolerance): each output slot is written independently with no reduction, so
+// the result is bit-identical regardless of policy or thread count.
+//
+// To exercise BOTH branches of the gate deterministically we drive the
+// evaluators with input sizes below and above the threshold AND temporarily
+// pin gbs::parallel_min_size to 0 (always parallel) / SIZE_MAX (always serial).
+
+namespace
+{
+    // RAII override of the global gate so a failing assertion cannot leak a
+    // mutated threshold into the next test case.
+    struct scoped_min_size
+    {
+        std::size_t saved;
+        explicit scoped_min_size(std::size_t v) : saved(gbs::parallel_min_size) { gbs::parallel_min_size = v; }
+        ~scoped_min_size() { gbs::parallel_min_size = saved; }
+    };
+
+    // Degree-3 open curve with a non-trivial control net (the light "value"
+    // kernel of the audit).
+    gbs::BSCurve<double, 3> make_curve()
+    {
+        const std::vector<double> knots{0., 0., 0., 0., 0.25, 0.5, 0.75, 1., 1., 1., 1.};
+        const gbs::points_vector<double, 3> poles{
+            {0., 0., 0.}, {1., 2., 0.}, {2., -1., 1.}, {3., 1., 2.},
+            {4., 0., 1.}, {5., 2., 0.}, {6., -1., 3.},
+        };
+        return gbs::BSCurve<double, 3>(poles, knots, 3);
+    }
+
+    // Bidegree-(3,3) open surface.
+    gbs::BSSurface<double, 3> make_surface()
+    {
+        const std::vector<double> ku{0., 0., 0., 0., 0.5, 1., 1., 1., 1.};
+        const std::vector<double> kv{0., 0., 0., 0., 0.5, 1., 1., 1., 1.};
+        gbs::points_vector<double, 3> poles;
+        poles.reserve(5 * 5);
+        for (int j = 0; j < 5; ++j)
+            for (int i = 0; i < 5; ++i)
+                poles.push_back({double(i), double(j), std::sin(0.7 * i) + std::cos(0.5 * j)});
+        return gbs::BSSurface<double, 3>(poles, ku, kv, 3, 3);
+    }
+
+    std::vector<double> make_params(std::size_t n, std::array<double, 2> bnds)
+    {
+        std::vector<double> u(n);
+        const double span = bnds[1] - bnds[0];
+        for (std::size_t i = 0; i < n; ++i)
+            u[i] = bnds[0] + span * (double(i) + 0.5) / double(n);
+        return u;
+    }
+
+    std::vector<std::array<double, 2>> make_uv(std::size_t n, std::array<double, 4> bnds)
+    {
+        std::vector<std::array<double, 2>> uv(n);
+        const double su = bnds[1] - bnds[0];
+        const double sv = bnds[3] - bnds[2];
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            const double t = (double(i) + 0.5) / double(n);
+            uv[i] = {bnds[0] + su * t, bnds[2] + sv * (1.0 - t)};
+        }
+        return uv;
+    }
+
+    // Sizes straddling the default gate (gbs::parallel_min_size == 1000).
+    constexpr std::size_t N_small = 50;    // below the gate -> serial branch
+    constexpr std::size_t N_large = 4096;  // above the gate -> parallel branch
+}
+
+// ---- the helper itself -----------------------------------------------------
+
+TEST(tests_parallel_eval, transform_threshold_unary_matches_serial)
+{
+    std::vector<double> in(N_large);
+    std::iota(in.begin(), in.end(), 0.0);
+    const auto op = [](double x) { return std::sin(x) * 2.0 - x; };
+
+    std::vector<double> ref(in.size());
+    std::transform(in.begin(), in.end(), ref.begin(), op);
+
+    for (std::size_t gate : {std::size_t(0), std::size_t(1000), std::numeric_limits<std::size_t>::max()})
+    {
+        scoped_min_size guard(gate);
+        std::vector<double> out(in.size());
+        gbs::transform_threshold(in.begin(), in.end(), out.begin(), op);
+        EXPECT_EQ(out, ref) << "gate=" << gate; // exact, policy must not change result
+    }
+}
+
+TEST(tests_parallel_eval, transform_threshold_binary_matches_serial)
+{
+    std::vector<double> a(N_large), b(N_large);
+    std::iota(a.begin(), a.end(), 0.0);
+    std::iota(b.begin(), b.end(), 1.0);
+    const auto op = [](double x, double y) { return x * y - std::cos(x); };
+
+    std::vector<double> ref(a.size());
+    std::transform(a.begin(), a.end(), b.begin(), ref.begin(), op);
+
+    for (std::size_t gate : {std::size_t(0), std::size_t(1000), std::numeric_limits<std::size_t>::max()})
+    {
+        scoped_min_size guard(gate);
+        std::vector<double> out(a.size());
+        gbs::transform_threshold(a.begin(), a.end(), b.begin(), out.begin(), op);
+        EXPECT_EQ(out, ref) << "gate=" << gate;
+    }
+}
+
+// ---- curve bulk evaluators -------------------------------------------------
+
+namespace
+{
+    template <class BulkFn, class RefFn>
+    void check_curve_eval(BulkFn bulk, RefFn ref_elem)
+    {
+        const auto crv = make_curve();
+        for (std::size_t n : {N_small, N_large})
+        {
+            const auto u = make_params(n, crv.bounds());
+            // Per-element serial reference.
+            gbs::points_vector<double, 3> ref(n);
+            std::transform(u.begin(), u.end(), ref.begin(),
+                           [&](double uu) { return ref_elem(crv, uu); });
+            // Bulk path with the gate forced to both branches.
+            for (std::size_t gate : {std::size_t(0), std::numeric_limits<std::size_t>::max()})
+            {
+                scoped_min_size guard(gate);
+                const auto got = bulk(crv, u);
+                ASSERT_EQ(got.size(), ref.size());
+                for (std::size_t i = 0; i < n; ++i)
+                    EXPECT_EQ(got[i], ref[i]) << "n=" << n << " gate=" << gate << " i=" << i;
+            }
+        }
+    }
+}
+
+TEST(tests_parallel_eval, curve_values_bit_identical)
+{
+    check_curve_eval(
+        [](const auto &c, const auto &u) { return c.values(u, 0); },
+        [](const auto &c, double u) { return c.value(u, 0); });
+}
+
+TEST(tests_parallel_eval, curve_values_first_derivative_bit_identical)
+{
+    check_curve_eval(
+        [](const auto &c, const auto &u) { return c.values(u, 1); },
+        [](const auto &c, double u) { return c.value(u, 1); });
+}
+
+TEST(tests_parallel_eval, curve_d_dms_bit_identical)
+{
+    check_curve_eval(
+        [](const auto &c, const auto &u) { return c.d_dms(u); },
+        [](const auto &c, double u) { return c.d_dm(u); });
+}
+
+TEST(tests_parallel_eval, curve_d_dm2s_bit_identical)
+{
+    check_curve_eval(
+        [](const auto &c, const auto &u) { return c.d_dm2s(u); },
+        [](const auto &c, double u) { return c.d_dm2(u); });
+}
+
+// ---- surface bulk evaluators -----------------------------------------------
+
+namespace
+{
+    template <class BulkFn, class RefFn>
+    void check_surface_eval(BulkFn bulk, RefFn ref_elem)
+    {
+        const auto srf = make_surface();
+        for (std::size_t n : {N_small, N_large})
+        {
+            const auto uv = make_uv(n, srf.bounds());
+            gbs::points_vector<double, 3> ref(n);
+            std::transform(uv.begin(), uv.end(), ref.begin(),
+                           [&](const auto &p) { return ref_elem(srf, p); });
+            for (std::size_t gate : {std::size_t(0), std::numeric_limits<std::size_t>::max()})
+            {
+                scoped_min_size guard(gate);
+                const auto got = bulk(srf, uv);
+                ASSERT_EQ(got.size(), ref.size());
+                for (std::size_t i = 0; i < n; ++i)
+                    EXPECT_EQ(got[i], ref[i]) << "n=" << n << " gate=" << gate << " i=" << i;
+            }
+        }
+    }
+}
+
+TEST(tests_parallel_eval, surface_values_bit_identical)
+{
+    check_surface_eval(
+        [](const auto &s, const auto &uv) { return s.values(uv, 0, 0); },
+        [](const auto &s, const auto &p) { return s.value(p[0], p[1], 0, 0); });
+}
+
+TEST(tests_parallel_eval, surface_d_dmus_bit_identical)
+{
+    check_surface_eval(
+        [](const auto &s, const auto &uv) { return s.d_dmus(uv); },
+        [](const auto &s, const auto &p) { return s.d_dmu(p[0], p[1]); });
+}
+
+TEST(tests_parallel_eval, surface_d_dmvs_bit_identical)
+{
+    check_surface_eval(
+        [](const auto &s, const auto &uv) { return s.d_dmvs(uv); },
+        [](const auto &s, const auto &p) { return s.d_dmv(p[0], p[1]); });
+}
+
+TEST(tests_parallel_eval, surface_d_dmu2s_bit_identical)
+{
+    check_surface_eval(
+        [](const auto &s, const auto &uv) { return s.d_dmu2s(uv); },
+        [](const auto &s, const auto &p) { return s.d_dmu2(p[0], p[1]); });
+}
+
+TEST(tests_parallel_eval, surface_d_dmv2s_bit_identical)
+{
+    check_surface_eval(
+        [](const auto &s, const auto &uv) { return s.d_dmv2s(uv); },
+        [](const auto &s, const auto &p) { return s.d_dmv2(p[0], p[1]); });
+}
+
+// The two-range surface values(u_lst, v_lst) overload.
+TEST(tests_parallel_eval, surface_values_two_ranges_bit_identical)
+{
+    const auto srf = make_surface();
+    const auto bnds = srf.bounds();
+    for (std::size_t n : {N_small, N_large})
+    {
+        const auto u = make_params(n, {bnds[0], bnds[1]});
+        const auto v = make_params(n, {bnds[2], bnds[3]});
+        gbs::points_vector<double, 3> ref(n);
+        for (std::size_t i = 0; i < n; ++i)
+            ref[i] = srf.value(u[i], v[i], 0, 0);
+        for (std::size_t gate : {std::size_t(0), std::numeric_limits<std::size_t>::max()})
+        {
+            scoped_min_size guard(gate);
+            const auto got = srf.values(u, v, 0, 0);
+            ASSERT_EQ(got.size(), ref.size());
+            for (std::size_t i = 0; i < n; ++i)
+                EXPECT_EQ(got[i], ref[i]) << "n=" << n << " gate=" << gate << " i=" << i;
+        }
+    }
+}


### PR DESCRIPTION
## What
From the parallelization audit (#84, `bench/PARALLEL_AUDIT.md`; thresholds measured in #92). Epic #44, pre-v1.0 perf track, **goal step 1** ("Bulk evaluation best-in-class").

The bulk multi-point evaluators are `std::transform` over an independent parameter list into a **pre-sized** output, but ran **serially**. Parallelizing is a measured **2–21×** win, but a bare `par` **regresses small calls up to 25×** (TBB spin-up). This PR lands a **size-gated** transform — not an unconditional policy — and routes every bulk evaluator through it.

## Changes
- **`gbs/execution.h`** — new shared helper `gbs::transform_threshold` (unary + binary overloads): dispatches `std::transform` to `GBS_PAR_EXEC` only when the range has `≥ gbs::parallel_min_size` elements, serial below. This is the helper **#89** (grid sampling) and **#91** (batch builds) will reuse.
- **`gbs/gbsconstants.h`** — tunable `gbs::parallel_min_size = 1000` (#38), the measured conservative break-even for the lightest kernel (curve `value`); heavier kernels cross over near ~64–128, so a known-heavy workload can lower it at runtime. Documented.
- **`gbs/bscurve.h`** — `values`, `d_dms`, `d_dm2s` routed; stale `// Parallelization doesn't seems to be worth` comment removed.
- **`gbs/bssurf.h`** — `values` (both overloads), `d_dmus`, `d_dmvs`, `d_dmu2s`, `d_dmv2s` routed; stale comments removed.

## Why it is safe
Each iteration writes a distinct, pre-indexed output slot; there is **no reduction**, so the result is **bit-identical** regardless of policy or thread count. The gate only selects the policy by size — it never changes the result. On platforms without parallel policies (Apple libc++), `GBS_PAR_EXEC` is empty so both branches are serial: a correctness-preserving no-op.

No double-parallelization introduced: `make_points` / curve `discretize` stay as-is.

## Tests
New `tests/tests_parallel_eval.cpp` asserts **exact** (`==`) bit-identity against a per-element serial reference for the helper itself and every bulk evaluator, exercising **both** gate branches (forced parallel via `parallel_min_size=0`, forced serial via `SIZE_MAX`) at sizes **below and above** the threshold — proving small calls keep the serial path and large calls match it exactly. 12 cases / ~83k assertions pass; the existing eval/derivative suites stay green.

Closes #88. Refs epic #44, #84.