### PR TITLE
perf(#91): batch interp/approx builder (parallel over N independent entities)

### DIFF
--- a/bench/PARALLEL_AUDIT.md
+++ b/bench/PARALLEL_AUDIT.md
@@ -289,7 +289,7 @@ determinism).
 | TFI grid + projection | `gbs-mesh/tfi.h:616,663` | **PAR-DONE** | `for_each`/`transform` `par` | — | portable |
 | Mesh area | `inc/topology/halfEdgeMeshQuality.h:76` | **PAR-DONE** | `reduce` `par` (`…AreaPar`) | — | fp-noise metric only |
 | Laplacian smoothing | `gbs-mesh/smoothing.h:35` | **PAR-MINOR** | Jacobi double-buffer per-vertex; `err_max` via `par` reduce | medium (iterative mesh loop) | portable; reduction is a scalar tol |
-| **Batch** interp/approx (N independent builds) | callers; `bscinterp.h`, `bscapprox.h`, `bssinterp.h` | **PAR-WIN** | `par` transform over the entity list (threshold-guarded) | **8–28× measured** (K=100–1000) | portable; no batch API yet, no internal serial loop |
+| **Batch** interp/approx (N independent builds) | `bscinterp.h`, `bscapprox.h`, `gbs/execution.h` | **PAR-DONE (#91)** | `build_batch` gated transform over the entity list | **3× @K=8 → 35× @K=1000 measured** | portable; batch overloads shipped, gate `parallel_batch_min_size`=8 |
 | Single-build interp/approx (assembly + solve) | `bscinterp.h:122,138`, `bscapprox.h` | **not worth (intra)** | banded assembly cheap (#34/#65); sparse factorization is sequential | low — Amdahl-capped; `dim` back-subs could batch (A5) | n/a |
 | Interp/approx **solve** (Eigen) | `bscinterp.h`, `bssinterp.h`, `bscapprox.h` | **SIMD-via-flags** | Eigen auto-vectorizes internally | gated on `-march`/AVX | build-flag; runtime dispatch for binaries |
 | Per-point evaluator (`find_span` + de Boor) | `gbslib.ixx`, `bscurve.h` | **SIMD/NA** | branchy search + short triangular recurrence | ~0% from `-march` (measured) | SoA refactor only, speculative |
@@ -379,6 +379,60 @@ correctly kept those calls serial. The win switches on exactly at
 
 The `[8]` section was added to `bench/bench_parallel.cpp` for this validation; run it
 with the same command below.
+
+## #91 — post-implementation validation (gated batch builders)
+
+#91 ships the **batch axis** the audit identified: building **N independent**
+curves/surfaces is embarrassingly parallel, so two threshold-guarded batch
+overloads were added and the outer loop routed through a new shared helper:
+
+- `gbs::build_batch(inputs, build, min_size)` (`gbs/execution.h`) — the batch
+  sibling of `transform_threshold`. It pre-sizes the output and runs the per-entity
+  builder under `par` only when the **build count** is `>= min_size` (default
+  `gbs::parallel_batch_min_size`), serial below. Each build owns its solver / matrix
+  / poles (the #96 band-LU is a per-call stack local — **no shared mutable state**),
+  so the result is **bit-identical** to the serial loop at any thread count.
+- `gbs::interpolate(std::vector<points_vector>, p, mode)` and
+  `gbs::approx(std::vector<points_vector>, p, n_poles, mode)` — batch overloads that
+  wrap the single-entity builders through `build_batch`. (No change to `bssbuild.h`:
+  the loft is a single tensor build, not an N-build loop — confirmed, so it is left
+  untouched and there is no overlap with #79/#80.)
+
+**Gate placement.** The batch gate is **separate and much lower** than the eval gate
+(`parallel_min_size = 1000`): each "element" is a whole banded solve, so the TBB
+spin-up (~9-15 µs) is amortized after a handful of builds. The fresh `[9a]` crossover
+sweep (gcc-15 `-O3` Release, libstdc++ + TBB, 64-hw-thread machine; the shipped
+overloads timed with the gate forced to MAX vs 0):
+
+| K builds | interpolate (80 pts, deg 3) | approx (400 pts → 50 poles) | result |
+|----------|------------------------------|------------------------------|--------|
+| 2   | 0.91× | 1.65× | bit-identical |
+| 4   | 1.78× | 2.58× | bit-identical |
+| 8   | 3.08× | 4.26× | bit-identical |
+| 16  | 5.30× | 9.20× | bit-identical |
+| 32  | 7.18× | 15.2× | bit-identical |
+| 64  | 9.78× | 18.8× | bit-identical |
+| 128 | 11.4× | 18.7× | bit-identical |
+
+Break-even is at **K ≈ 3–4** for both builders; the only sub-break-even row is K=2
+interpolate (0.91×). So `gbs::parallel_batch_min_size` is set to **8** — a safe margin
+above the measured crossover that still captures the 3×+ band (the heavier `approx`
+crosses even earlier, so 8 is conservative for it). The original `[7a]/[7b]` replicas
+confirm the win keeps scaling: **34–35×** at K=1000. A known-heavy workload may lower
+the gate toward ~4.
+
+**Production-gate check `[9b]`** drives the shipped overloads at the default gate (8):
+K=4 takes the **serial** branch (no regression), K≥8 takes `par`, every row
+bit-identical to the per-entity serial loop — the gate switches exactly at
+`parallel_batch_min_size`.
+
+Unit coverage: `tests/tests_batch_build.cpp` pins `gbs::parallel_batch_min_size` to 0
+(always par) and SIZE_MAX (always serial) and checks the batch `interpolate`/`approx`
+output **pole- and knot-exact** against the per-entity serial loop (independent of the
+default gate), plus the generic `build_batch` helper and its empty-input case.
+
+The `[9a]/[9b]` sections were added to `bench/bench_parallel.cpp`; run with the command
+below.
 
 ## Reproduce
 ```

--- a/bench/bench_parallel.cpp
+++ b/bench/bench_parallel.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <execution>
 #include <functional>
+#include <limits>
 #include <vector>
 
 using namespace gbs; // bring the gbs vecop operators (^, +, *, /) into scope
@@ -411,6 +412,80 @@ int main()
             const char *pol = (N >= gbs::parallel_min_size) ? "par" : "seq";
             std::printf("%-8zu %14.3f %14.3f %11.2fx  %s/%s\n", N, sus, gus, sus / gus,
                         pol, bit_identical(ref, got) ? "identical" : "DIFFERS");
+        }
+    }
+
+    // ---- 9. SHIPPED gated batch builders (#91) ----------------------------
+    // Sections [7a]/[7b] timed raw std::transform replicas. This drives the
+    // *shipped* gbs::interpolate(inputs,...) / gbs::approx(inputs,...) batch
+    // overloads, which route the outer loop through gbs::build_batch (gate
+    // gbs::parallel_batch_min_size). [9a] brackets the seq-vs-par crossover by
+    // forcing the gate to MAX (always serial) vs 0 (always parallel), locating
+    // where par overtakes seq — which justifies the default gate. [9b] then runs
+    // the production default gate to confirm it picks serial below / parallel
+    // above, bit-identical to the per-entity serial loop in every row.
+    {
+        constexpr size_t ALWAYS_SEQ = std::numeric_limits<size_t>::max();
+        auto bit_same_batch = [](const auto &a, const auto &b) {
+            if (a.size() != b.size()) return false;
+            for (size_t k = 0; k < a.size(); ++k)
+                if (a[k].poles() != b[k].poles() || a[k].knotsFlats() != b[k].knotsFlats())
+                    return false;
+            return true;
+        };
+        struct gate_guard {
+            size_t saved;
+            explicit gate_guard(size_t v) : saved(gbs::parallel_batch_min_size) { gbs::parallel_batch_min_size = v; }
+            ~gate_guard() { gbs::parallel_batch_min_size = saved; }
+        };
+        auto make_sets = [](size_t K, size_t n_pts) {
+            std::vector<points_vector<double, 3>> in(K);
+            for (size_t k = 0; k < K; ++k) {
+                in[k].resize(n_pts);
+                double ph = double(k) / double(K);
+                for (size_t i = 0; i < n_pts; ++i) {
+                    double t = double(i) / double(n_pts - 1);
+                    in[k][i] = {std::cos(6.0 * t + ph), std::sin(6.0 * t + ph), 2.0 * t};
+                }
+            }
+            return in;
+        };
+
+        std::printf("\n[9a] SHIPPED BATCH crossover  (gbs::interpolate/approx over K sets, gate forced)\n");
+        std::printf("%-12s %-8s %12s %12s %10s %s\n", "builder", "K", "seq ms", "par ms", "speedup", "result");
+        std::printf("----------------------------------------------------------------------------\n");
+        for (size_t K : {size_t{2}, size_t{4}, size_t{8}, size_t{16}, size_t{32}, size_t{64}, size_t{128}}) {
+            auto in = make_sets(K, 80);
+            std::vector<BSCurve<double, 3>> seq_r, par_r;
+            double sms = best_ms(5, [&] { gate_guard g(ALWAYS_SEQ); seq_r = interpolate<double, 3>(in, size_t{3}, KnotsCalcMode::CHORD_LENGTH); });
+            double pms = best_ms(5, [&] { gate_guard g(0);          par_r = interpolate<double, 3>(in, size_t{3}, KnotsCalcMode::CHORD_LENGTH); });
+            sink += par_r[0].poles()[0][0];
+            std::printf("%-12s %-8zu %12.4f %12.4f %9.2fx  %s\n", "interpolate", K, sms, pms, sms / pms,
+                        bit_same_batch(seq_r, par_r) ? "identical" : "DIFFERS");
+        }
+        for (size_t K : {size_t{2}, size_t{4}, size_t{8}, size_t{16}, size_t{32}, size_t{64}, size_t{128}}) {
+            auto in = make_sets(K, 400);
+            std::vector<BSCurve<double, 3>> seq_r, par_r;
+            double sms = best_ms(5, [&] { gate_guard g(ALWAYS_SEQ); seq_r = approx<double, 3>(in, size_t{3}, size_t{50}, KnotsCalcMode::CHORD_LENGTH); });
+            double pms = best_ms(5, [&] { gate_guard g(0);          par_r = approx<double, 3>(in, size_t{3}, size_t{50}, KnotsCalcMode::CHORD_LENGTH); });
+            sink += par_r[0].poles()[0][0];
+            std::printf("%-12s %-8zu %12.4f %12.4f %9.2fx  %s\n", "approx", K, sms, pms, sms / pms,
+                        bit_same_batch(seq_r, par_r) ? "identical" : "DIFFERS");
+        }
+
+        std::printf("\n[9b] PRODUCTION GATE  (default gbs::parallel_batch_min_size = %zu)\n", gbs::parallel_batch_min_size);
+        std::printf("%-12s %-8s %12s %s\n", "builder", "K", "ms", "policy/result");
+        std::printf("----------------------------------------------------------------\n");
+        for (size_t K : {size_t{4}, size_t{8}, size_t{16}, size_t{32}, size_t{100}}) {
+            auto in = make_sets(K, 80);
+            std::vector<BSCurve<double, 3>> ref(K);
+            std::transform(in.begin(), in.end(), ref.begin(),
+                           [](const auto &Q) { return interpolate<double, 3>(Q, size_t{3}, KnotsCalcMode::CHORD_LENGTH); });
+            std::vector<BSCurve<double, 3>> got;
+            double ms = best_ms(5, [&] { got = interpolate<double, 3>(in, size_t{3}, KnotsCalcMode::CHORD_LENGTH); });
+            const char *pol = (K >= gbs::parallel_batch_min_size) ? "par" : "seq";
+            std::printf("%-12s %-8zu %12.4f %s/%s\n", "interpolate", K, ms, pol,
+                        bit_same_batch(ref, got) ? "identical" : "DIFFERS");
         }
     }
 

--- a/gbs/bscapprox.h
+++ b/gbs/bscapprox.h
@@ -7,6 +7,7 @@
 #include <Eigen/SparseCholesky>
 #include <gbs/bssinterp.h>
 #include <gbs/bscanalysis.h>
+#include <gbs/execution.h>  // gbs::build_batch (#91 batch approx)
 
 namespace gbs
 {
@@ -308,6 +309,20 @@ namespace gbs
     {
         auto u = curve_parametrization(pts, mode, adimensionnal);
         return approx(pts, p, n_poles, u, true);
+    }
+
+    // Batch approximation (#91): least-squares-fit N INDEPENDENT curves from N
+    // point sets, each through the single-entity approx() above. The outer loop is
+    // threshold-guarded parallel via build_batch (gate gbs::parallel_batch_min_size):
+    // each build owns its normal-equations solver/poles, so the result is
+    // bit-identical to a serial loop regardless of thread count. The single
+    // per-curve solve stays sequential — no useful intra-build parallel axis (#84).
+    template <typename T, size_t dim>
+    auto approx(const std::vector<std::vector<std::array<T, dim>>> &pts_lst, size_t p, size_t n_poles, KnotsCalcMode mode, bool adimensionnal = false)
+        -> std::vector<BSCurve<T, dim>>
+    {
+        return build_batch(pts_lst, [p, n_poles, mode, adimensionnal](const std::vector<std::array<T, dim>> &pts)
+                           { return approx<T, dim>(pts, p, n_poles, mode, adimensionnal); });
     }
 
     // Sample a curve by deviation and return the point set together with its

--- a/gbs/bscinterp.h
+++ b/gbs/bscinterp.h
@@ -621,9 +621,23 @@ auto interpolate(const points_vector<T,dim> &Q, size_t p, KnotsCalcMode mode ) -
     return interpolate<T,dim>(Q_,p,mode);
 }
 
+// Batch interpolation (#91): build N INDEPENDENT curves from N point sets, each
+// through the single-entity interpolate() above. The outer loop over the sets is
+// threshold-guarded parallel via build_batch (gate gbs::parallel_batch_min_size):
+// the builds are independent (each owns its solver/poles), so the result is
+// bit-identical to a serial loop regardless of thread count. The single per-curve
+// solve stays sequential — there is no useful intra-build parallel axis (#84).
+template <typename T, size_t dim>
+auto interpolate(const std::vector<points_vector<T, dim>> &Q_lst, size_t p, KnotsCalcMode mode)
+    -> std::vector<BSCurve<T, dim>>
+{
+    return build_batch(Q_lst, [p, mode](const points_vector<T, dim> &Q)
+                       { return interpolate<T, dim>(Q, p, mode); });
+}
+
 template <typename T, size_t dim>
 auto interpolate(const points_vector<T,dim> &Q,const std::vector<T> &u, size_t p ) -> BSCurve<T, dim>
-{ 
+{
     std::vector<constrType<T, dim, 1>> Q_(Q.size());
     std::transform(Q.begin(),Q.end(),Q_.begin(),[](const auto &pt_){return constrType<T, dim, 1>{pt_};});
     return interpolate<T,dim>(Q_,u,p);

--- a/gbs/execution.h
+++ b/gbs/execution.h
@@ -5,8 +5,10 @@
 #include <version>
 #include <numeric>  // std::reduce, std::transform_reduce (previously transitive via <execution>)
 #include <algorithm>  // std::transform
-#include <iterator>   // std::distance
+#include <iterator>   // std::distance, std::begin/end/size
 #include <cstddef>    // std::size_t
+#include <vector>     // std::vector (build_batch output)
+#include <type_traits> // std::decay_t (build_batch result type)
 
 #include "gbsconstants.h"  // gbs::parallel_min_size
 
@@ -77,6 +79,43 @@ namespace gbs
         if (static_cast<std::size_t>(std::distance(first1, last1)) >= parallel_min_size)
             return std::transform(GBS_PAR_EXEC first1, last1, first2, out, op);
         return std::transform(first1, last1, first2, out, op);
+    }
+
+    // -------------------------------------------------------------------------
+    // Size-gated parallel BATCH build — the shared helper for batch builders.
+    // -------------------------------------------------------------------------
+    // Applies `build` to each input entity and returns the results in input
+    // order. The sibling of transform_threshold for the interp/approx BATCH axis
+    // (#91): building N INDEPENDENT curves/surfaces (loft-section sweeps,
+    // multi-patch models, fitting batches) is embarrassingly parallel — each
+    // build owns its solver/matrix/poles. Unlike transform_threshold, the gate is
+    // the COUNT of builds (gbs::parallel_batch_min_size), not a per-element count:
+    // each "element" here is a whole banded solve, so the crossover sits far below
+    // parallel_min_size (see gbsconstants.h / PARALLEL_AUDIT.md [7]/[9]).
+    //
+    // Reentrancy / determinism: every build constructs its own object with NO
+    // shared mutable state (the band-LU/sparse solver of #96 is a per-call stack
+    // local) and writes a distinct, pre-indexed output slot, with no reduction.
+    // The result is therefore BIT-IDENTICAL to the serial loop regardless of the
+    // policy chosen or the thread count (#91, cf. #48). Below the gate, and on
+    // platforms without parallel policies (Apple libc++ -> GBS_PAR_EXEC empty),
+    // both branches are serial and the gate is a correctness-preserving no-op.
+    //
+    // `Result` (the builder's return type) must be default-constructible, since
+    // the output is pre-sized for the parallel slot-by-slot write; BSCurve /
+    // BSSurface are.
+    template <class InputRange, class Builder>
+    auto build_batch(const InputRange &inputs, Builder build,
+                     std::size_t min_size = parallel_batch_min_size)
+        -> std::vector<std::decay_t<decltype(build(*std::begin(inputs)))>>
+    {
+        using Result = std::decay_t<decltype(build(*std::begin(inputs)))>;
+        std::vector<Result> out(static_cast<std::size_t>(std::size(inputs)));
+        if (out.size() >= min_size)
+            std::transform(GBS_PAR_EXEC std::begin(inputs), std::end(inputs), out.begin(), build);
+        else
+            std::transform(std::begin(inputs), std::end(inputs), out.begin(), build);
+        return out;
     }
 }
 

--- a/gbs/gbsconstants.h
+++ b/gbs/gbsconstants.h
@@ -70,6 +70,22 @@ namespace gbs
     // tuned at runtime per workload.
     inline std::size_t parallel_min_size = 1000;
 
+    // ---- Parallel BATCH-build size gate ------------------------------------
+    // Separate, much lower gate for building N INDEPENDENT entities (batch
+    // interpolate/approx of many curves/surfaces — loft-section sweeps,
+    // multi-patch models, fitting batches). Here the parallel axis is the COUNT
+    // of builds, and each "element" is a whole interpolate()/approx() — a heavy
+    // banded solve, orders of magnitude more work than one bulk-evaluation point.
+    // The TBB spin-up (~9-15 us) is therefore amortized after only a handful of
+    // builds, so the crossover sits far below parallel_min_size: the batch bench
+    // (PARALLEL_AUDIT.md [9a], #84/#92) measures break-even at K~3-4 builds and a
+    // 3x win already at K=8, rising to 11-19x at K=128 and 28-35x at K=1000.
+    // 8 is the conservative default — a safe margin above the measured break-even
+    // (the only sub-break-even row is K=2 interpolate at 0.91x) that still captures
+    // the 3x+ band. gbs::build_batch (gbs/execution.h) gates the outer loop on this
+    // value. Mutable so a known-heavy workload can lower it further (toward ~4).
+    inline std::size_t parallel_batch_min_size = 8;
+
     // ---- Curve/surface intersection & extrema tolerance --------------------
     // Default tolerance for extrema / intersection / projection searches
     // (extrema_curve_curve, build_intersections, gordon, closest_curve, ...).

--- a/tests/tests_batch_build.cpp
+++ b/tests/tests_batch_build.cpp
@@ -1,0 +1,144 @@
+#include <doctest_gtest.hpp>
+#include <gbs/bscurve.h>
+#include <gbs/bscinterp.h>
+#include <gbs/bscapprox.h>
+#include <gbs/execution.h>
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+// Coverage for #91: the batch interp/approx builders run the outer loop over N
+// INDEPENDENT entities through gbs::build_batch, which routes the loop to the
+// parallel execution policy only above gbs::parallel_batch_min_size. The gate
+// only chooses the policy by the build COUNT; it must NEVER change the result.
+// Each build constructs its own object (own solver/poles, no shared state) and
+// writes a distinct pre-indexed slot with no reduction, so every batch result is
+// bit-identical to the per-entity serial loop — checked here with EXACT equality
+// (operator==, no tolerance). Both gate branches are exercised by pinning
+// gbs::parallel_batch_min_size to 0 (always parallel) / SIZE_MAX (always serial).
+
+namespace
+{
+    // RAII override of the global batch gate so a failing assertion cannot leak a
+    // mutated threshold into the next test case.
+    struct scoped_batch_min_size
+    {
+        std::size_t saved;
+        explicit scoped_batch_min_size(std::size_t v)
+            : saved(gbs::parallel_batch_min_size) { gbs::parallel_batch_min_size = v; }
+        ~scoped_batch_min_size() { gbs::parallel_batch_min_size = saved; }
+    };
+
+    // K distinct point sets: a helix whose phase shifts per entity, so every build
+    // produces a genuinely different curve (not K copies of one solve).
+    std::vector<gbs::points_vector<double, 3>> make_inputs(std::size_t K, std::size_t n_pts)
+    {
+        std::vector<gbs::points_vector<double, 3>> inputs(K);
+        for (std::size_t k = 0; k < K; ++k)
+        {
+            auto &Q = inputs[k];
+            Q.resize(n_pts);
+            const double ph = double(k) / double(K == 0 ? 1 : K);
+            for (std::size_t i = 0; i < n_pts; ++i)
+            {
+                const double t = double(i) / double(n_pts - 1);
+                Q[i] = {std::cos(6.0 * t + ph), std::sin(6.0 * t + ph), 2.0 * t};
+            }
+        }
+        return inputs;
+    }
+
+    // Exact, component-by-component equality of two curves (poles + knots + degree).
+    void expect_same_curve(const gbs::BSCurve<double, 3> &got,
+                           const gbs::BSCurve<double, 3> &ref, std::size_t k)
+    {
+        ASSERT_EQ(got.degree(), ref.degree());
+        ASSERT_EQ(got.poles().size(), ref.poles().size());
+        ASSERT_EQ(got.knotsFlats().size(), ref.knotsFlats().size());
+        for (std::size_t i = 0; i < ref.poles().size(); ++i)
+            EXPECT_EQ(got.poles()[i], ref.poles()[i]) << "k=" << k << " pole=" << i;
+        for (std::size_t i = 0; i < ref.knotsFlats().size(); ++i)
+            EXPECT_EQ(got.knotsFlats()[i], ref.knotsFlats()[i]) << "k=" << k << " knot=" << i;
+    }
+
+    // Sizes straddling any plausible gate: small (serial branch) and large enough
+    // to exercise the real parallel branch when the gate is forced to 0.
+    constexpr std::size_t K_small = 5;
+    constexpr std::size_t K_large = 200;
+}
+
+// ---- the generic helper ----------------------------------------------------
+
+TEST(tests_batch_build, build_batch_matches_serial)
+{
+    std::vector<int> in(K_large);
+    for (std::size_t i = 0; i < in.size(); ++i) in[i] = int(i);
+    const auto build = [](int x) { return x * x - 3 * x; };
+
+    std::vector<int> ref(in.size());
+    std::transform(in.begin(), in.end(), ref.begin(), build);
+
+    for (std::size_t gate : {std::size_t(0), std::size_t(32), std::numeric_limits<std::size_t>::max()})
+    {
+        const auto got = gbs::build_batch(in, build, gate);
+        EXPECT_EQ(got, ref) << "gate=" << gate;
+    }
+}
+
+TEST(tests_batch_build, build_batch_empty_input)
+{
+    const std::vector<int> in;
+    const auto got = gbs::build_batch(in, [](int x) { return x; });
+    EXPECT_TRUE(got.empty());
+}
+
+// ---- batch interpolate -----------------------------------------------------
+
+TEST(tests_batch_build, batch_interpolate_bit_identical)
+{
+    for (std::size_t K : {K_small, K_large})
+    {
+        const auto inputs = make_inputs(K, 80);
+
+        // Per-entity serial reference (the loop the batch API replaces).
+        std::vector<gbs::BSCurve<double, 3>> ref;
+        ref.reserve(K);
+        for (const auto &Q : inputs)
+            ref.push_back(gbs::interpolate<double, 3>(Q, std::size_t{3}, gbs::KnotsCalcMode::CHORD_LENGTH));
+
+        for (std::size_t gate : {std::size_t(0), std::numeric_limits<std::size_t>::max()})
+        {
+            scoped_batch_min_size guard(gate);
+            const auto got = gbs::interpolate<double, 3>(inputs, std::size_t{3}, gbs::KnotsCalcMode::CHORD_LENGTH);
+            ASSERT_EQ(got.size(), ref.size());
+            for (std::size_t k = 0; k < K; ++k)
+                expect_same_curve(got[k], ref[k], k);
+        }
+    }
+}
+
+// ---- batch approx ----------------------------------------------------------
+
+TEST(tests_batch_build, batch_approx_bit_identical)
+{
+    for (std::size_t K : {K_small, K_large})
+    {
+        const auto inputs = make_inputs(K, 400);
+
+        std::vector<gbs::BSCurve<double, 3>> ref;
+        ref.reserve(K);
+        for (const auto &Q : inputs)
+            ref.push_back(gbs::approx<double, 3>(Q, std::size_t{3}, std::size_t{50}, gbs::KnotsCalcMode::CHORD_LENGTH));
+
+        for (std::size_t gate : {std::size_t(0), std::numeric_limits<std::size_t>::max()})
+        {
+            scoped_batch_min_size guard(gate);
+            const auto got = gbs::approx<double, 3>(inputs, std::size_t{3}, std::size_t{50}, gbs::KnotsCalcMode::CHORD_LENGTH);
+            ASSERT_EQ(got.size(), ref.size());
+            for (std::size_t k = 0; k < K; ++k)
+                expect_same_curve(got[k], ref[k], k);
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds the **batch axis** the parallelization audit (#84, `bench/PARALLEL_AUDIT.md` §5/[7]) identified for the interp/approx builders. Building **N independent** curves/surfaces (loft-section sweeps, multi-patch models, fitting batches) is embarrassingly parallel; a single build has no useful intra-build axis (banded sequential solve, already fast post #96), so the parallel axis is the batch.

- **`gbs::build_batch`** (`gbs/execution.h`) — the batch sibling of `transform_threshold`. Pre-sizes the output and runs the per-entity builder under `par` only when the build **count** is `>= gbs::parallel_batch_min_size`, serial below.
- **Batch overloads** — `interpolate(std::vector<points_vector>, p, mode)` and `approx(std::vector<points_vector>, p, n_poles, mode)`, each wrapping the single-entity builder through `build_batch`.
- **`gbs::parallel_batch_min_size`** (`gbs/gbsconstants.h`) `= 8` — a separate, much lower gate than the eval gate (`1000`) because each element here is a whole banded solve, so the TBB spin-up amortizes after a handful of builds.

## Safety / reentrance

Each build constructs its own object with **no shared mutable state** — the #96 no-pivot band-LU (`collocation_solver`) is a per-call stack local, verified (no `static`/`thread_local` in the build path). Each write goes to a distinct pre-indexed slot, no reduction ⇒ **bit-identical** to the serial loop at any thread count (cf. #48). On libc++ (no parallel policies) the gate is a serial no-op.

## Measured (`bench_parallel` [9a], gcc-15 `-O3` Release, libstdc++ + TBB, 64-hw-thread)

| K builds | interpolate (80 pts, deg 3) | approx (400 pts → 50 poles) | result |
|----------|------------------------------|------------------------------|--------|
| 2   | 0.91× | 1.65× | bit-identical |
| 4   | 1.78× | 2.58× | bit-identical |
| 8   | 3.08× | 4.26× | bit-identical |
| 32  | 7.18× | 15.2× | bit-identical |
| 128 | 11.4× | 18.7× | bit-identical |
| 1000 | 34.1× | 35.2× ([7a]/[7b]) | bit-identical |

Break-even at **K ≈ 3–4**; `parallel_batch_min_size = 8` is a safe margin capturing the 3×+ band. `[9b]` confirms the production gate picks serial below 8, `par` at/above, bit-identical to the per-entity serial loop.

## Scope

The loft is a single tensor build (not an N-build loop), so **`bssbuild.h` is left untouched** — no overlap with #79/#80.

## Tests

`tests/tests_batch_build.cpp` pins the gate to `0` (always par) and `SIZE_MAX` (always serial) and checks batch `interpolate`/`approx` **pole- and knot-exact** against the per-entity serial loop, plus the generic `build_batch` helper and its empty-input case. All pass (incl. `tests_bsinterp`, `tests_parallel_eval`, `tests_bssbuild` — no regression).

Closes #91. Refs #44 (epic), #88 (`transform_threshold`), #84 (audit).