### PR TITLE
perf(#91): propagate builder exceptions out of the parallel build_batch

### DIFF
--- a/gbs/execution.h
+++ b/gbs/execution.h
@@ -4,11 +4,12 @@
 // Fall back to sequential algorithms on that platform.
 #include <version>
 #include <numeric>  // std::reduce, std::transform_reduce (previously transitive via <execution>)
-#include <algorithm>  // std::transform
-#include <iterator>   // std::distance, std::begin/end/size
+#include <algorithm>  // std::transform, std::for_each
+#include <iterator>   // std::distance, std::begin/end/size/next
 #include <cstddef>    // std::size_t
 #include <vector>     // std::vector (build_batch output)
 #include <type_traits> // std::decay_t (build_batch result type)
+#include <exception>  // std::exception_ptr (build_batch error propagation)
 
 #include "gbsconstants.h"  // gbs::parallel_min_size
 
@@ -101,20 +102,44 @@ namespace gbs
     // platforms without parallel policies (Apple libc++ -> GBS_PAR_EXEC empty),
     // both branches are serial and the gate is a correctness-preserving no-op.
     //
+    // Exceptions: a builder may throw on a malformed entity (e.g. interpolate on
+    // < deg+1 points). An exception escaping a parallel element-access function
+    // calls std::terminate per the standard, so each build is wrapped: the first
+    // failure (lowest index, as a serial loop would throw) is captured and
+    // RETHROWN to the caller after the parallel region — identical, catchable
+    // behavior on either side of the gate. (Builds are side-effect-free, so
+    // running the rest of the batch before rethrowing only wastes work on error.)
+    //
     // `Result` (the builder's return type) must be default-constructible, since
     // the output is pre-sized for the parallel slot-by-slot write; BSCurve /
     // BSSurface are.
     template <class InputRange, class Builder>
     auto build_batch(const InputRange &inputs, Builder build,
                      std::size_t min_size = parallel_batch_min_size)
-        -> std::vector<std::decay_t<decltype(build(*std::begin(inputs)))>>
     {
         using Result = std::decay_t<decltype(build(*std::begin(inputs)))>;
-        std::vector<Result> out(static_cast<std::size_t>(std::size(inputs)));
-        if (out.size() >= min_size)
-            std::transform(GBS_PAR_EXEC std::begin(inputs), std::end(inputs), out.begin(), build);
+        const std::size_t n = static_cast<std::size_t>(std::size(inputs));
+        std::vector<Result> out(n);
+        std::vector<std::exception_ptr> errs(n); // slot i set iff build i threw
+
+        // Drive build i into the distinct slot out[i] (no aliasing across i, so
+        // the writes are race-free), trapping any throw so it cannot escape the
+        // parallel element function.
+        std::vector<std::size_t> idx(n);
+        for (std::size_t i = 0; i < n; ++i) idx[i] = i;
+        const auto run = [&](std::size_t i)
+        {
+            try { out[i] = build(*std::next(std::begin(inputs), static_cast<std::ptrdiff_t>(i))); }
+            catch (...) { errs[i] = std::current_exception(); }
+        };
+        if (n >= min_size)
+            std::for_each(GBS_PAR_EXEC idx.begin(), idx.end(), run);
         else
-            std::transform(std::begin(inputs), std::end(inputs), out.begin(), build);
+            std::for_each(idx.begin(), idx.end(), run);
+
+        for (std::size_t i = 0; i < n; ++i)
+            if (errs[i]) std::rethrow_exception(errs[i]); // first failure, as serial
+
         return out;
     }
 }

--- a/tests/tests_batch_build.cpp
+++ b/tests/tests_batch_build.cpp
@@ -119,6 +119,25 @@ TEST(tests_batch_build, batch_interpolate_bit_identical)
     }
 }
 
+// A malformed entity must surface as a CATCHABLE exception on either side of the
+// gate — never std::terminate (which the parallel branch would call if a build's
+// exception were allowed to escape the element function). With the gate forced to
+// 0 (always parallel) the un-trapped version of this would crash the test process.
+TEST(tests_batch_build, batch_interpolate_propagates_exception)
+{
+    auto inputs = make_inputs(K_large, 80);
+    inputs[K_large / 2].resize(2); // too few points for a degree-3 interpolation
+
+    // Wrap in a lambda so the comma in interpolate<double, 3> does not split the
+    // EXPECT_ANY_THROW macro arguments.
+    const auto run = [&] { return gbs::interpolate<double, 3>(inputs, std::size_t{3}, gbs::KnotsCalcMode::CHORD_LENGTH); };
+    for (std::size_t gate : {std::size_t(0), std::numeric_limits<std::size_t>::max()})
+    {
+        scoped_batch_min_size guard(gate);
+        EXPECT_ANY_THROW((void)run()) << "gate=" << gate;
+    }
+}
+
 // ---- batch approx ----------------------------------------------------------
 
 TEST(tests_batch_build, batch_approx_bit_identical)


### PR DESCRIPTION
## Summary

Follow-up hardening for the #91 batch builder (`gbs::build_batch`, merged in #100). It drives each build through a parallel `std::for_each` above the size gate, but a builder can **throw** on a malformed entity (e.g. `interpolate` on fewer than `deg+1` points). An exception escaping a parallel element-access function calls **`std::terminate`** per the C++ standard — so the parallel batch would crash the whole process instead of surfacing a catchable error, and would behave differently from the serial branch.

**Fix:** wrap each build in a `try/catch` that captures the failure as a `std::exception_ptr` in a per-index slot; after the parallel region, rethrow the **first (lowest-index)** failure — exactly the exception a serial loop would have thrown. Identical, catchable behavior on both sides of the gate. Builds are side-effect-free, so on error the batch only wastes the remaining work before rethrowing.

## Test

`tests_batch_build.batch_interpolate_propagates_exception` makes one entity malformed (2 points for a degree-3 interpolation) and asserts a **catchable** throw with the gate forced to both `0` (always parallel) and `SIZE_MAX` (always serial). The un-trapped version `std::terminate`s the test process at gate 0. All 5 batch tests pass (112k assertions).

Refs #91, epic #44.
