### PR TITLE
perf(#89): pre-size + parallelize grid sampling (offset_points, discretize)

### DIFF
--- a/gbs/bssanalysis.h
+++ b/gbs/bssanalysis.h
@@ -7,32 +7,24 @@ namespace gbs
     template <typename T, size_t dim>
     auto discretize(const Surface<T, dim> &srf, size_t nu, size_t nv) -> points_vector<T, dim>
     {
-        points_vector<T, dim> points;
         auto [u1, u2, v1, v2] = srf.bounds();
         auto u = make_range(u1, u2, nu);
         auto v = make_range(v1, v2, nv);
 
-        std::for_each(
-            v.begin(),
-            v.end(),
-            [&srf, &u, &points, nu](const auto &v_) // mutable
-            {
-                points_vector<T, dim> points_(nu);
-                std::transform(
-                    GBS_PAR_EXEC
-                    u.begin(),
-                    u.end(),
-                    points_.begin(),
-                    [&srf, v_](const auto &u_)
-                    {
-                        return srf(u_, v_);
-                    });
+        // Pre-size to nu*nv and evaluate the flattened (u,v) grid in one size-gated
+        // parallel transform (#89), keeping the U-first, V-outer order. This drops
+        // the serial outer v-loop with insert() (and its double-parallelization: a
+        // par transform nested in a serial for_each) for a single flat transform —
+        // each node writes a distinct slot, so the result is bit-identical.
+        std::vector<std::array<T, 2>> uv(nu * nv);
+        for (size_t j = 0; j < nv; ++j)
+            for (size_t i = 0; i < nu; ++i)
+                uv[j * nu + i] = {u[i], v[j]};
 
-                points.insert(
-                    points.end(),
-                    std::make_move_iterator(points_.begin()),
-                    std::make_move_iterator(points_.end()));
-            });
+        points_vector<T, dim> points(nu * nv);
+        transform_threshold(
+            uv.begin(), uv.end(), points.begin(),
+            [&srf](const std::array<T, 2> &uv_) { return srf(uv_[0], uv_[1]); });
 
         return points;
     }

--- a/gbs/offsets.h
+++ b/gbs/offsets.h
@@ -1,30 +1,37 @@
 #pragma once
 #include <gbs/bssapprox.h>
 #include <gbs/bssurf.h>
+#include <gbs/execution.h>
 namespace gbs
 {
     template <typename T>
     auto offset_points(const BSSfunction<T> &f_ep, const Surface<T, 3> &cl_srf, const std::vector<T> &u, const std::vector<T> &v)
     {
-        size_t nu = u.size();
-        size_t nv = v.size();
-        points_vector<T, 3> pts;
-        T u_, v_;
-        for (auto j = 0; j < nv; j++)
-        {
-            v_ = v[j];
-            for (auto i = 0; i < nu; i++)
+        const size_t nu = u.size();
+        const size_t nv = v.size();
+        // Flatten the (u,v) grid in the existing U-first, V-outer order, then run
+        // the offset kernel (value + du + dv + normal + offset) as one size-gated
+        // parallel transform writing each node to its own slot (#89). Each node is
+        // an independent surface eval, so the result is bit-identical to the old
+        // nested push_back loop — just no longer serialized by a growing container.
+        std::vector<std::array<T, 2>> uv(nu * nv);
+        for (size_t j = 0; j < nv; ++j)
+            for (size_t i = 0; i < nu; ++i)
+                uv[j * nu + i] = {u[i], v[j]};
+
+        points_vector<T, 3> pts(nu * nv);
+        transform_threshold(
+            uv.begin(), uv.end(), pts.begin(),
+            [&f_ep, &cl_srf](const std::array<T, 2> &uv_) -> point<T, 3>
             {
-                u_ = u[i];
+                const T u_ = uv_[0], v_ = uv_[1];
                 auto pt = cl_srf(u_, v_);
                 auto tu = cl_srf(u_, v_, 1, 0);
                 auto tv = cl_srf(u_, v_, 0, 1);
                 auto n = tu ^ tv;
                 n = n / norm(n);
-                pt = pt + n * f_ep(u_, v_);
-                pts.push_back(pt);
-            }
-        }
+                return pt + n * f_ep(u_, v_);
+            });
         return pts;
     }
 


### PR DESCRIPTION
## Summary

From the parallelization audit (#84). Two grid-sampling paths grew a shared container in a serial loop, blocking the eval speedup:

- `offset_points` (`gbs/offsets.h`) — nested `(u,v)` loop with `pts.push_back`.
- `discretize(Surface)` (`gbs/bssanalysis.h`) — serial outer `v`-loop with `points.insert`; only the inner `u`-slice was `par` (a `par`-in-serial double-parallelization smell).

**Fix:** flatten the `(u,v)` grid in the existing **U-first, V-outer** order, pre-size the output to `nu*nv`, and run **one** size-gated `transform_threshold` (the #88 helper) writing each node to its own slot. Each node is an independent surface eval (offset kernel = value + ∂u + ∂v + normal + offset), so the result is **bit-identical** to the old order — only the growing container is replaced by an indexed write.

## Measured (serial vs parallel, 64-thread box)

| N | offset_points | discretize |
|---|---------------|------------|
| 1 024 | 5.6× | 3.0× |
| 10 000 | 10.4× | 3.4× |
| 100 489 | 18.1× | 7.4× |
| 1 000 000 | **22.4×** | 8.2× |

`offset_points` (fully serial before) tracks the audit's 6.7–20.9×; `discretize` is a lighter per-node kernel but the flat form also removes the serial outer `insert()` and the double-parallelization.

## Correctness
A scratch harness confirmed both functions are **bit-identical** to the old nested-loop order and **parallel (gate 0) == serial (gate SIZE_MAX)** — `max|Δ| = 0` on a non-square 37×29 grid. All surface suites pass: `tests_surfaces`, `tests_bssurf`, `tests_bssbuild`, `tests_surface_derivatives`.

Closes #89. Refs #84, epic #44.
